### PR TITLE
Pin hdf4 version to resolve netCDF4 error

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - openmoltools >=0.7.4
     - ambermini >=15.0.4
     - netcdf4 >=1.2.4
+    - hdf4=4.2.12 # Pinned because of issue with netcdf4
     - joblib
     - lxml
     - parmed
@@ -28,6 +29,7 @@ requirements:
     - numpy >=1.10
     - scipy >=0.17.0
     - netcdf4 >=1.2.4
+    - hdf4=4.2.12 # Pinned because of issue with netcdf4
     - openmoltools >=0.7.0
     - ambermini <=15.0.4
     - joblib

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - openmoltools >=0.7.4
     - ambermini >=15.0.4
     - netcdf4 >=1.2.4
-    - hdf4=4.2.12 # Pinned because of issue with netcdf4
+    - hdf4 <=4.2.12 # Pinned because of issue with netcdf4
     - joblib
     - lxml
     - parmed
@@ -29,9 +29,9 @@ requirements:
     - numpy >=1.10
     - scipy >=0.17.0
     - netcdf4 >=1.2.4
-    - hdf4=4.2.12 # Pinned because of issue with netcdf4
+    - hdf4 <=4.2.12 # Pinned because of issue with netcdf4
     - openmoltools >=0.7.0
-    - ambermini <=15.0.4
+    - ambermini >=15.0.4
     - joblib
     - lxml
     - parmed

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - openmoltools >=0.7.4
     - ambermini >=15.0.4
     - netcdf4 >=1.2.4
-    - hdf4 <=4.2.12 # Pinned because of issue with netcdf4
+    - hdf4 >4.2.11 # Pinned because of issue with netcdf4
     - joblib
     - lxml
     - parmed
@@ -29,7 +29,7 @@ requirements:
     - numpy >=1.10
     - scipy >=0.17.0
     - netcdf4 >=1.2.4
-    - hdf4 <=4.2.12 # Pinned because of issue with netcdf4
+    - hdf4 >4.2.11 # Pinned because of issue with netcdf4
     - openmoltools >=0.7.0
     - ambermini >=15.0.4
     - joblib


### PR DESCRIPTION
Travis python 2.7 build showing this error. It might be fixable by pinning the hdf4 version to 4.2.12.

```==================================== ERRORS ====================================
______________________________ ERROR collecting  _______________________________
ImportError while importing test module '/home/travis/miniconda3/envs/test/lib/python2.7/site-packages/protons-0.0.0-py2.7.egg/protons/tests/test_record.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../../miniconda3/envs/test/lib/python2.7/site-packages/protons-0.0.0-py2.7.egg/protons/tests/test_record.py:12: in <module>
    from protons import record
../../../../miniconda3/envs/test/lib/python2.7/site-packages/protons-0.0.0-py2.7.egg/protons/record.py:5: in <module>
    import netCDF4
../../../../miniconda3/envs/test/lib/python2.7/site-packages/netCDF4/__init__.py:3: in <module>
    from ._netCDF4 import *
E   ImportError: libmfhdf.so.0: cannot open shared object file: No such file or directory
```