### PR TITLE
Fix ligand atom type assignment for ponatinib

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     - openmm >=7.1
     - numpy >=1.10
     - scipy >=0.17.0
-    - openmoltools >=0.7.4
+    - openmoltools >=0.7.5
     - openmmtools >=0.9.3
     - ambermini >=15.0.4
     - netcdf4 >=1.2.4
@@ -31,7 +31,7 @@ requirements:
     - scipy >=0.17.0
     - netcdf4 >=1.2.4
     - hdf4 >4.2.11 # Pinned because of issue with netcdf4
-    - openmoltools >=0.7.0
+    - openmoltools >=0.7.5
     - openmmtools >=0.9.3
     - ambermini >=15.0.4
     - joblib


### PR DESCRIPTION
Why:
The algorithm that was in place for selecting a single set of atom types
 for all states could not provide a solution for ponatinib. This
implements a new algorithm that bases the atom types on the most
populated state, and then checks if bonded types are available.

If there are no bonds defined for the types between two bonded atoms,
 it proceeds to try an atom type from the next populated state for one,
 the other, or both atoms.

How:

I've implemented a new function in ligands.py that replaces the old one.
For legacy reasons I've left the old one in place so it can still be
 accessed through the objects private API if desired.