### PR TITLE
Add reference GBAOAB implementation

### DIFF
--- a/protons/calibration.py
+++ b/protons/calibration.py
@@ -11,7 +11,7 @@ import abc
 from . import get_data
 from scipy.misc import logsumexp
 from collections import deque
-from protons.integrators import GHMCIntegrator, BAOABIntegrator
+from protons.integrators import GHMCIntegrator, ReferenceGBAOABIntegrator
 kB = (1.0 * units.BOLTZMANN_CONSTANT_kB * units.AVOGADRO_CONSTANT_NA).in_units_of(units.kilocalories_per_mole / units.kelvin)
 
 

--- a/protons/tests/test_implicit.py
+++ b/protons/tests/test_implicit.py
@@ -6,7 +6,6 @@ from simtk import unit, openmm
 from simtk.openmm import app
 
 from protons import AmberProtonDrive
-from protons.integrators import GHMCIntegrator
 from protons.calibration import SelfAdjustedMixtureSampling, AmberCalibrationSystem
 from . import get_test_data
 from .utilities import SystemSetup, create_compound_gbaoab_integrator, create_compound_ghmc_integrator

--- a/protons/tests/test_integrators.py
+++ b/protons/tests/test_integrators.py
@@ -1,0 +1,99 @@
+from openmmtools import testsystems
+from simtk import unit
+from simtk.openmm import openmm
+from protons.integrators import ReferenceGBAOABIntegrator
+from .utilities import almost_equal
+import pytest
+
+
+class TestGBAOABIntegrator(object):
+    """Tests the GBAOAB integrator work accumulation"""
+    def test_protocol_work_accumulation_harmonic_oscillator(self):
+        """Testing protocol work accumulation for ExternalPerturbationLangevinIntegrator with HarmonicOscillator
+        """
+        testsystem = testsystems.HarmonicOscillator()
+        parameter_name = 'testsystems_HarmonicOscillator_x0'
+        parameter_initial = 0.0 * unit.angstroms
+        parameter_final = 10.0 * unit.angstroms
+        for platform_name in ['Reference', 'CPU']:
+            self.compare_external_protocol_work_accumulation(testsystem, parameter_name, parameter_initial, parameter_final, platform_name=platform_name)
+
+    def test_protocol_work_accumulation_waterbox(self):
+        """Testing protocol work accumulation for ExternalPerturbationLangevinIntegrator with AlchemicalWaterBox
+        """
+        from simtk.openmm import app
+        parameter_name = 'lambda_electrostatics'
+        parameter_initial = 1.0
+        parameter_final = 0.0
+        platform_names = [ openmm.Platform.getPlatform(index).getName() for index in range(openmm.Platform.getNumPlatforms()) ]
+        for nonbonded_method in ['CutoffPeriodic', 'PME']:
+            testsystem = testsystems.AlchemicalWaterBox(nonbondedMethod=getattr(app, nonbonded_method))
+            for platform_name in platform_names:
+                name = '%s %s %s' % (testsystem.name, nonbonded_method, platform_name)
+                self.compare_external_protocol_work_accumulation(testsystem, parameter_name, parameter_initial, parameter_final, platform_name=platform_name, name=name)
+
+    def test_protocol_work_accumulation_waterbox_barostat(self):
+        """
+        Testing protocol work accumulation for ExternalPerturbationLangevinIntegrator with AlchemicalWaterBox
+        with an active barostat. For brevity, only using CutoffPeriodic as the non-bonded method.
+        """
+        from simtk.openmm import app
+        parameter_name = 'lambda_electrostatics'
+        parameter_initial = 1.0
+        parameter_final = 0.0
+        platform_names = [ openmm.Platform.getPlatform(index).getName() for index in range(openmm.Platform.getNumPlatforms()) ]
+        nonbonded_method = 'CutoffPeriodic'
+        testsystem = testsystems.AlchemicalWaterBox(nonbondedMethod=getattr(app, nonbonded_method))
+
+        # Adding the barostat with a high frequency
+        testsystem.system.addForce(openmm.MonteCarloBarostat(1*unit.atmospheres, 300*unit.kelvin, 2))
+
+        for platform_name in platform_names:
+            name = '%s %s %s' % (testsystem.name, nonbonded_method, platform_name)
+            self.compare_external_protocol_work_accumulation(testsystem, parameter_name, parameter_initial, parameter_final, platform_name=platform_name, name=name)
+
+
+    def compare_external_protocol_work_accumulation(self, testsystem, parameter_name, parameter_initial, parameter_final, platform_name='Reference', name=None):
+        """Compare external work accumulation between Reference and CPU platforms.
+        """
+
+        if name is None:
+            name = testsystem.name
+
+        from openmmtools.constants import kB
+        system, topology = testsystem.system, testsystem.topology
+        temperature = 298.0 * unit.kelvin
+        platform = openmm.Platform.getPlatformByName(platform_name)
+
+        # TODO: Set precision and determinism if platform is ['OpenCL', 'CUDA']
+
+        nsteps = 20
+        kT = kB * temperature
+        integrator = ReferenceGBAOABIntegrator(temperature=temperature)
+        context = openmm.Context(system, integrator, platform)
+        context.setParameter(parameter_name, parameter_initial)
+        context.setPositions(testsystem.positions)
+        context.setVelocitiesToTemperature(temperature)
+        assert(integrator.getGlobalVariableByName('protocol_work') == 0), "Protocol work should be 0 initially"
+        integrator.step(1)
+        assert(integrator.getGlobalVariableByName('protocol_work') == 0), "There should be no protocol work."
+
+        external_protocol_work = 0.0
+        for step in range(nsteps):
+            lambda_value = float(step+1) / float(nsteps)
+            parameter_value = parameter_initial * (1-lambda_value) + parameter_final * lambda_value
+            initial_energy = context.getState(getEnergy=True).getPotentialEnergy()
+            context.setParameter(parameter_name, parameter_value)
+            final_energy = context.getState(getEnergy=True).getPotentialEnergy()
+            external_protocol_work += (final_energy - initial_energy) / kT
+
+            integrator.step(1)
+            integrator_protocol_work = integrator.getGlobalVariableByName('protocol_work') * unit.kilojoules_per_mole / kT
+
+            message = '\n'
+            message += 'protocol work discrepancy noted for %s on platform %s\n' % (name, platform_name)
+            message += 'step %5d : external %16e kT | integrator %16e kT | difference %16e kT' % (step, external_protocol_work, integrator_protocol_work, external_protocol_work - integrator_protocol_work)
+            # Test relative tolerance
+            assert pytest.approx(external_protocol_work, 0.001) == integrator_protocol_work, message
+
+        del context, integrator

--- a/protons/tests/test_integrators.py
+++ b/protons/tests/test_integrators.py
@@ -2,7 +2,6 @@ from openmmtools import testsystems
 from simtk import unit
 from simtk.openmm import openmm
 from protons.integrators import ReferenceGBAOABIntegrator
-from .utilities import almost_equal
 import pytest
 
 

--- a/protons/tests/utilities.py
+++ b/protons/tests/utilities.py
@@ -2,8 +2,7 @@ from __future__ import print_function
 from simtk import unit, openmm
 from simtk.openmm import app
 from protons import *
-import protons.integrators
-import openmmtools.integrators
+from protons.integrators import GHMCIntegrator, ReferenceGBAOABIntegrator as GBAOABIntegrator
 import logging
 
 
@@ -33,6 +32,7 @@ except Exception as e:
 class SystemSetup:
     """Empty class for storing systems and relevant attributes"""
     pass
+
 
 
 def make_method(func, input):
@@ -189,9 +189,9 @@ def create_compound_ghmc_integrator(testsystem):
     -------
     simtk.openmm.openmm.CompoundIntegrator
     """
-    integrator = protons.integrators.GHMCIntegrator(temperature=testsystem.temperature, collision_rate=testsystem.collision_rate,
+    integrator = GHMCIntegrator(temperature=testsystem.temperature, collision_rate=testsystem.collision_rate,
                                 timestep=testsystem.timestep, nsteps=testsystem.nsteps_per_ghmc)
-    ncmc_propagation_integrator = protons.integrators.GHMCIntegrator(temperature=testsystem.temperature,
+    ncmc_propagation_integrator = GHMCIntegrator(temperature=testsystem.temperature,
                                                  collision_rate=testsystem.collision_rate,
                                                  timestep=testsystem.timestep, nsteps=testsystem.nsteps_per_ghmc)
     compound_integrator = openmm.CompoundIntegrator()
@@ -212,9 +212,9 @@ def create_compound_gbaoab_integrator(testsystem):
     -------
     simtk.openmm.openmm.CompoundIntegrator
     """
-    integrator = protons.integrators.BAOABIntegrator(temperature=testsystem.temperature, collision_rate=testsystem.collision_rate,
+    integrator = GBAOABIntegrator(temperature=testsystem.temperature, collision_rate=testsystem.collision_rate,
                                                      timestep=testsystem.timestep, constraint_tolerance=testsystem.constraint_tolerance)
-    ncmc_propagation_integrator = protons.integrators.BAOABIntegrator(temperature=testsystem.temperature, collision_rate=testsystem.collision_rate,
+    ncmc_propagation_integrator = GBAOABIntegrator(temperature=testsystem.temperature, collision_rate=testsystem.collision_rate,
                                                      timestep=testsystem.timestep, constraint_tolerance=testsystem.constraint_tolerance)
     compound_integrator = openmm.CompoundIntegrator()
     compound_integrator.addIntegrator(integrator)


### PR DESCRIPTION
I've created a reference implementation of GBAOAB integration method, which took about 20 minutes in total. I've added tests to ensure correctness, and for now this should offer a stable API.

Once we're done with the grant and paper we can revisit the openmmtools repository integrators but as of yet, they're too unstable to be a dependency for this project. I can't afford to relearn the API every day and then update the protons code to support it again.

This change addresses the need by:

* Adding a ReferenceGBAOABIntegrator to protons.integrators.
* Adding tests for this integrator in protons/tests/test_integrators.py
* Updating the tests and code in other locations to support this integrator.

The openmmtools integrator codebase seems to be undergoing several API changes every other day.  This is fine, and to be expected for a research project, but it makes it hard to sustain as a dependency. I can't afford to spend time changing my code every time a dependency makes a minor incremental change, whilst overhauling its entire API. With the way development has been going, every time the openmmtools code changes its API, protons needs to change its implementation.

It becomes harder and harder to do so because apparently, the ExternalPerturbationLangevinIntegrator now has an init function that takes only ` *args, **kwargs` with no documentation. I don't know how to use this, and since we need to focus on getting simulation data out, we can't at this point in time afford to spend much effort refactoring to enable features of integrators not necessary for our June 5th deadline.



