### PR TITLE
Fix major ForceFieldProtonDrive atom indexing bug

### DIFF
--- a/protons/driver.py
+++ b/protons/driver.py
@@ -10,8 +10,6 @@ import re
 import sys
 import numpy as np
 import simtk
-from enum import Enum
-from heapq import heappush, heappop
 from simtk import unit as units
 from simtk.openmm import app
 

--- a/protons/tests/test_ff.py
+++ b/protons/tests/test_ff.py
@@ -236,6 +236,93 @@ def test_create_peptide_simulation_with_residue_pools_using_protons_xml():
     # to class side effects
     app.Topology.unloadStandardBonds()
 
+def pattern_from_multiline(multiline, pattern):
+    """Return only lines that contain the pattern
+
+    Parameters
+    ----------
+    multiline - multiline str        
+    pattern - str
+
+    Returns
+    -------
+    multiline str containing pattern
+    """
+
+    return '\n'.join([line for line in multiline.splitlines() if pattern in line])
+
+
+def test_peptide_system_integrity():
+    """
+    Set up peptide, and assure that the systems particles have not been modified after driver instantiation.
+    """
+
+    sys_details = SystemSetup()
+    sys_details.timestep = 0.5 * unit.femtoseconds
+    sys_details.temperature = 300. * unit.kelvin
+    sys_details.collision_rate = 1. / unit.picosecond
+    sys_details.pressure = 1.0 * unit.atmospheres
+    sys_details.barostatInterval = 25
+    sys_details.constraint_tolerance = 1.e-7
+
+    app.Topology.loadBondDefinitions(ff.bonds)
+
+    # Load pdb file with protons compatible residue names
+    pdbx = app.PDBxFile(
+        get_test_data(
+            'glu_ala_his-solvated-minimized-renamed.cif',
+            'testsystems/tripeptides'))
+    forcefield = app.ForceField(ff.protonsff, ff.ions_spce, 'spce.xml')
+
+    # System Configuration
+    nonbondedMethod = app.PME
+    constraints = app.AllBonds
+    rigidWater = True
+    sys_details.constraintTolerance = 1.e-7
+
+    # Simulation Options
+    platform = mm.Platform.getPlatformByName('Reference')
+
+    # Prepare the Simulation
+    topology = pdbx.topology
+    positions = pdbx.positions
+    system = forcefield.createSystem(
+        topology,
+        nonbondedMethod=nonbondedMethod,
+        constraints=constraints,
+        rigidWater=rigidWater,
+    )
+    system.addForce(
+        mm.MonteCarloBarostat(
+            sys_details.pressure,
+            sys_details.temperature,
+            sys_details.barostatInterval))
+
+    integrator = create_compound_gbaoab_integrator(testsystem=sys_details)
+
+    original_system = pattern_from_multiline(mm.XmlSerializer.serialize(system), '<Particle')
+
+    driver = ForceFieldProtonDrive(
+        system, sys_details.temperature, 7.0, [ff.protonsff], forcefield,
+        topology, integrator, debug=False, pressure=sys_details.pressure,
+        ncmc_steps_per_trial=1, implicit=False, cationName="NA",
+        anionName="CL")
+
+    after_driver = pattern_from_multiline(mm.XmlSerializer.serialize(system), '<Particle')
+
+    # Clean up so that the classes remain unmodified
+    # unit test specific errors might occur otherwise when loading files due
+    # to class side effects
+    app.Topology.unloadStandardBonds()
+
+    # Make sure there are no differences between the particles in each system
+    assert original_system == after_driver
+
+
+
+
+
+
 
 @pytest.mark.skip(reason="Still creating input file.")
 def test_create_hewl_simulation_using_protons_xml():

--- a/protons/tests/test_ff.py
+++ b/protons/tests/test_ff.py
@@ -139,7 +139,7 @@ def test_create_peptide_simulation_using_protons_xml():
 
 
     driver = ForceFieldProtonDrive(
-        system, sys_details.temperature, 7.0, [ff.protonsff],
+        system, sys_details.temperature, 7.0, [ff.protonsff], forcefield,
         topology, integrator, debug=False, pressure=sys_details.pressure,
         ncmc_steps_per_trial=1, implicit=False, cationName="NA",
         anionName="CL")
@@ -211,7 +211,7 @@ def test_create_peptide_simulation_with_residue_pools_using_protons_xml():
     integrator = create_compound_gbaoab_integrator(testsystem=sys_details)
 
     driver = ForceFieldProtonDrive(
-        system, sys_details.temperature, 7.0, [ff.protonsff],
+        system, sys_details.temperature, 7.0, [ff.protonsff], forcefield,
         topology, integrator, debug=False, pressure=sys_details.pressure,
         ncmc_steps_per_trial=1, implicit=False, cationName="NA",
         anionName="CL")

--- a/protons/tests/test_integrators.py
+++ b/protons/tests/test_integrators.py
@@ -3,6 +3,7 @@ from simtk import unit
 from simtk.openmm import openmm
 from protons.integrators import ReferenceGBAOABIntegrator
 import pytest
+import os
 
 
 class TestGBAOABIntegrator(object):
@@ -17,6 +18,7 @@ class TestGBAOABIntegrator(object):
         for platform_name in ['Reference', 'CPU']:
             self.compare_external_protocol_work_accumulation(testsystem, parameter_name, parameter_initial, parameter_final, platform_name=platform_name)
 
+    @pytest.mark.skipif(os.environ.get("TRAVIS", None) == 'true', reason="Skip slow test on travis.")
     def test_protocol_work_accumulation_waterbox(self):
         """Testing protocol work accumulation for ExternalPerturbationLangevinIntegrator with AlchemicalWaterBox
         """
@@ -31,6 +33,7 @@ class TestGBAOABIntegrator(object):
                 name = '%s %s %s' % (testsystem.name, nonbonded_method, platform_name)
                 self.compare_external_protocol_work_accumulation(testsystem, parameter_name, parameter_initial, parameter_final, platform_name=platform_name, name=name)
 
+    @pytest.mark.skipif(os.environ.get("TRAVIS", None) == 'true', reason="Skip slow test on travis.")
     def test_protocol_work_accumulation_waterbox_barostat(self):
         """
         Testing protocol work accumulation for ExternalPerturbationLangevinIntegrator with AlchemicalWaterBox

--- a/protons/tests/test_record.py
+++ b/protons/tests/test_record.py
@@ -9,7 +9,7 @@ from simtk import unit
 from simtk.openmm import openmm, app
 
 from protons import ForceFieldProtonDrive
-from protons import record
+from protons import record, ff
 import pytest
 from protons.integrators import GHMCIntegrator
 from . import get_test_data
@@ -27,11 +27,13 @@ def setup_forcefield_drive():
     testsystem.collision_rate = 1.0 / unit.picoseconds
     testsystem.pH = 9.6
     testsystems = get_test_data('imidazole_explicit', 'testsystems')
+
     testsystem.positions = openmm.XmlSerializer.deserialize(
         open('{}/imidazole-explicit.state.xml'.format(testsystems)).read()).getPositions(asNumpy=True)
     testsystem.system = openmm.XmlSerializer.deserialize(
         open('{}/imidazole-explicit.sys.xml'.format(testsystems)).read())
     testsystem.ffxml_filename = '{}/protons-imidazole.xml'.format(testsystems)
+    testsystem.forcefield = app.ForceField(ff.gaff, testsystem.ffxml_filename)
     testsystem.gaff = get_test_data("gaff.xml", "../forcefields/")
     testsystem.pdbfile = app.PDBFile(
         get_test_data("imidazole-solvated-minimized.pdb", "testsystems/imidazole_explicit"))
@@ -41,7 +43,7 @@ def setup_forcefield_drive():
     integrator = create_compound_gbaoab_integrator(testsystem)
 
     drive = ForceFieldProtonDrive(testsystem.system, testsystem.temperature, testsystem.pH,
-                                  [testsystem.ffxml_filename],
+                                  [testsystem.ffxml_filename], testsystem.forcefield,
                                   testsystem.topology, integrator, debug=False,
                                   pressure=testsystem.pressure, ncmc_steps_per_trial=2, implicit=False,
                                   residues_by_name=['LIG'], nattempts_per_update=1)


### PR DESCRIPTION
This fixes a major bug in the `ForceFieldProtonDrive`. The bug was caused
by the assumption that atoms, for which indices from the topology were
retrieved were assumed to be in the same order as the forcefield
template.

This fix makes use of code from `simtk.openmm.app.forcefield`
to match residue template atoms to topology atoms. It then makes sure
that the topology atom indices for each atom in the template are
assigned correctly.

The `ForceFieldProtonDrive` requires forcefield information to correctly
match indices, so this resulted in a breaking API change.
`ForceFieldProtonDrive` now requires the user to provide the `forcefield`
argument to `__init__`.