### PR TITLE
Correctly propagate group index in SAMS

### DIFF
--- a/protons/calibration.py
+++ b/protons/calibration.py
@@ -90,7 +90,7 @@ class SelfAdjustedMixtureSampling(object):
         self.n_adaptations += 1
 
         # zeta^{t-1}
-        zeta = self.get_gk()
+        zeta = self.get_gk(group_index=group_index)
 
         if scheme == 'binary':
             update = self._binary_update(group_index=group_index, b=b, stage=stage, end_of_burnin=end_of_burnin)

--- a/protons/tests/test_ff.py
+++ b/protons/tests/test_ff.py
@@ -162,84 +162,6 @@ def test_create_peptide_simulation_using_protons_xml():
 
 def test_create_peptide_simulation_with_residue_pools_using_protons_xml():
     """Test if protons.xml can be used to successfully create a peptide Simulation object in OpenMM and
-    Instantiate a ForceFieldProtonDrive, while using pools of residues to sample from,
-    and calibrate histidine."""
-
-    sys_details = SystemSetup()
-    sys_details.timestep = 0.5 * unit.femtoseconds
-    sys_details.temperature = 300. * unit.kelvin
-    sys_details.collision_rate = 1. / unit.picosecond
-    sys_details.pressure = 1.0 * unit.atmospheres
-    sys_details.barostatInterval = 25
-    sys_details.constraint_tolerance = 1.e-7
-
-    app.Topology.loadBondDefinitions(ff.bonds)
-
-    # Load pdb file with protons compatible residue names
-    pdbx = app.PDBxFile(
-        get_test_data(
-            'glu_ala_his-solvated-minimized-renamed.cif',
-            'testsystems/tripeptides'))
-    forcefield = app.ForceField(ff.protonsff, ff.ions_spce, 'spce.xml')
-
-    # System Configuration
-    nonbondedMethod = app.PME
-    constraints = app.AllBonds
-    rigidWater = True
-    sys_details.constraintTolerance = 1.e-7
-
-
-
-    # Simulation Options
-    platform = mm.Platform.getPlatformByName('Reference')
-
-    # Prepare the Simulation
-    topology = pdbx.topology
-    positions = pdbx.positions
-    system = forcefield.createSystem(
-        topology,
-        nonbondedMethod=nonbondedMethod,
-        constraints=constraints,
-        rigidWater=rigidWater,
-    )
-    system.addForce(
-        mm.MonteCarloBarostat(
-            sys_details.pressure,
-            sys_details.temperature,
-            sys_details.barostatInterval))
-
-    integrator = create_compound_gbaoab_integrator(testsystem=sys_details)
-
-    driver = ForceFieldProtonDrive(
-        system, sys_details.temperature, 7.0, [ff.protonsff], forcefield,
-        topology, integrator, debug=False, pressure=sys_details.pressure,
-        ncmc_steps_per_trial=1, implicit=False, cationName="NA",
-        anionName="CL")
-
-    pools = {'glu' : [0], 'his': [1],  'glu-his' : [0,1] }
-
-    driver.define_pools(pools)
-    sams_sampler = SelfAdjustedMixtureSampling(driver, 1) # SAMS on HIS
-    simulation = app.Simulation(
-        topology,
-        system,
-        driver.compound_integrator,
-        platform)
-    simulation.context.setPositions(positions)
-    simulation.context.setVelocitiesToTemperature(sys_details.temperature)
-
-    # run one step and one update
-    simulation.step(1)
-    driver.update(simulation.context, nattempts=1, residue_pool='his')
-    sams_sampler.adapt_zetas(simulation.context, scheme='binary', b=0.85, stage="slow-gain", end_of_burnin=0, group_index=1)
-    # Clean up so that the classes remain unmodified
-    # unit test specific errors might occur otherwise when loading files due
-    # to class side effects
-    app.Topology.unloadStandardBonds()
-
-
-def test_create_peptide_calibration_with_residue_pools_using_protons_xml():
-    """Test if protons.xml can be used to successfully create a peptide Simulation object in OpenMM and
     Instantiate a ForceFieldProtonDrive, while using pools of residues to sample from."""
 
     sys_details = SystemSetup()
@@ -329,6 +251,83 @@ def pattern_from_multiline(multiline, pattern):
 
     return '\n'.join([line for line in multiline.splitlines() if pattern in line])
 
+
+def test_create_peptide_calibration_with_residue_pools_using_protons_xml():
+    """Test if protons.xml can be used to successfully create a peptide Simulation object in OpenMM and
+    Instantiate a ForceFieldProtonDrive, while using pools of residues to sample from,
+    and calibrate histidine."""
+
+    sys_details = SystemSetup()
+    sys_details.timestep = 0.5 * unit.femtoseconds
+    sys_details.temperature = 300. * unit.kelvin
+    sys_details.collision_rate = 1. / unit.picosecond
+    sys_details.pressure = 1.0 * unit.atmospheres
+    sys_details.barostatInterval = 25
+    sys_details.constraint_tolerance = 1.e-7
+
+    app.Topology.loadBondDefinitions(ff.bonds)
+
+    # Load pdb file with protons compatible residue names
+    pdbx = app.PDBxFile(
+        get_test_data(
+            'glu_ala_his-solvated-minimized-renamed.cif',
+            'testsystems/tripeptides'))
+    forcefield = app.ForceField(ff.protonsff, ff.ions_spce, 'spce.xml')
+
+    # System Configuration
+    nonbondedMethod = app.PME
+    constraints = app.AllBonds
+    rigidWater = True
+    sys_details.constraintTolerance = 1.e-7
+
+
+
+    # Simulation Options
+    platform = mm.Platform.getPlatformByName('Reference')
+
+    # Prepare the Simulation
+    topology = pdbx.topology
+    positions = pdbx.positions
+    system = forcefield.createSystem(
+        topology,
+        nonbondedMethod=nonbondedMethod,
+        constraints=constraints,
+        rigidWater=rigidWater,
+    )
+    system.addForce(
+        mm.MonteCarloBarostat(
+            sys_details.pressure,
+            sys_details.temperature,
+            sys_details.barostatInterval))
+
+    integrator = create_compound_gbaoab_integrator(testsystem=sys_details)
+
+    driver = ForceFieldProtonDrive(
+        system, sys_details.temperature, 7.0, [ff.protonsff], forcefield,
+        topology, integrator, debug=False, pressure=sys_details.pressure,
+        ncmc_steps_per_trial=1, implicit=False, cationName="NA",
+        anionName="CL")
+
+    pools = {'glu' : [0], 'his': [1],  'glu-his' : [0,1] }
+
+    driver.define_pools(pools)
+    sams_sampler = SelfAdjustedMixtureSampling(driver, 1) # SAMS on HIS
+    simulation = app.Simulation(
+        topology,
+        system,
+        driver.compound_integrator,
+        platform)
+    simulation.context.setPositions(positions)
+    simulation.context.setVelocitiesToTemperature(sys_details.temperature)
+
+    # run one step and one update
+    simulation.step(1)
+    driver.update(simulation.context, nattempts=1, residue_pool='his')
+    sams_sampler.adapt_zetas(simulation.context, scheme='binary', b=0.85, stage="slow-gain", end_of_burnin=0, group_index=1)
+    # Clean up so that the classes remain unmodified
+    # unit test specific errors might occur otherwise when loading files due
+    # to class side effects
+    app.Topology.unloadStandardBonds()
 
 def test_peptide_system_integrity():
     """

--- a/protons/tests/test_ff.py
+++ b/protons/tests/test_ff.py
@@ -6,6 +6,7 @@ from simtk import unit
 from simtk.openmm import app, openmm as mm
 
 from protons import ff, integrators, ForceFieldProtonDrive
+from protons.calibration import SelfAdjustedMixtureSampling
 from . import get_test_data
 from .utilities import create_compound_gbaoab_integrator, SystemSetup
 
@@ -115,8 +116,6 @@ def test_create_peptide_simulation_using_protons_xml():
     rigidWater = True
     sys_details.constraintTolerance = 1.e-7
 
-
-
     # Simulation Options
     platform = mm.Platform.getPlatformByName('Reference')
 
@@ -162,6 +161,84 @@ def test_create_peptide_simulation_using_protons_xml():
 
 
 def test_create_peptide_simulation_with_residue_pools_using_protons_xml():
+    """Test if protons.xml can be used to successfully create a peptide Simulation object in OpenMM and
+    Instantiate a ForceFieldProtonDrive, while using pools of residues to sample from,
+    and calibrate histidine."""
+
+    sys_details = SystemSetup()
+    sys_details.timestep = 0.5 * unit.femtoseconds
+    sys_details.temperature = 300. * unit.kelvin
+    sys_details.collision_rate = 1. / unit.picosecond
+    sys_details.pressure = 1.0 * unit.atmospheres
+    sys_details.barostatInterval = 25
+    sys_details.constraint_tolerance = 1.e-7
+
+    app.Topology.loadBondDefinitions(ff.bonds)
+
+    # Load pdb file with protons compatible residue names
+    pdbx = app.PDBxFile(
+        get_test_data(
+            'glu_ala_his-solvated-minimized-renamed.cif',
+            'testsystems/tripeptides'))
+    forcefield = app.ForceField(ff.protonsff, ff.ions_spce, 'spce.xml')
+
+    # System Configuration
+    nonbondedMethod = app.PME
+    constraints = app.AllBonds
+    rigidWater = True
+    sys_details.constraintTolerance = 1.e-7
+
+
+
+    # Simulation Options
+    platform = mm.Platform.getPlatformByName('Reference')
+
+    # Prepare the Simulation
+    topology = pdbx.topology
+    positions = pdbx.positions
+    system = forcefield.createSystem(
+        topology,
+        nonbondedMethod=nonbondedMethod,
+        constraints=constraints,
+        rigidWater=rigidWater,
+    )
+    system.addForce(
+        mm.MonteCarloBarostat(
+            sys_details.pressure,
+            sys_details.temperature,
+            sys_details.barostatInterval))
+
+    integrator = create_compound_gbaoab_integrator(testsystem=sys_details)
+
+    driver = ForceFieldProtonDrive(
+        system, sys_details.temperature, 7.0, [ff.protonsff], forcefield,
+        topology, integrator, debug=False, pressure=sys_details.pressure,
+        ncmc_steps_per_trial=1, implicit=False, cationName="NA",
+        anionName="CL")
+
+    pools = {'glu' : [0], 'his': [1],  'glu-his' : [0,1] }
+
+    driver.define_pools(pools)
+    sams_sampler = SelfAdjustedMixtureSampling(driver, 1) # SAMS on HIS
+    simulation = app.Simulation(
+        topology,
+        system,
+        driver.compound_integrator,
+        platform)
+    simulation.context.setPositions(positions)
+    simulation.context.setVelocitiesToTemperature(sys_details.temperature)
+
+    # run one step and one update
+    simulation.step(1)
+    driver.update(simulation.context, nattempts=1, residue_pool='his')
+    sams_sampler.adapt_zetas(simulation.context, scheme='binary', b=0.85, stage="slow-gain", end_of_burnin=0, group_index=1)
+    # Clean up so that the classes remain unmodified
+    # unit test specific errors might occur otherwise when loading files due
+    # to class side effects
+    app.Topology.unloadStandardBonds()
+
+
+def test_create_peptide_calibration_with_residue_pools_using_protons_xml():
     """Test if protons.xml can be used to successfully create a peptide Simulation object in OpenMM and
     Instantiate a ForceFieldProtonDrive, while using pools of residues to sample from."""
 
@@ -235,6 +312,7 @@ def test_create_peptide_simulation_with_residue_pools_using_protons_xml():
     # unit test specific errors might occur otherwise when loading files due
     # to class side effects
     app.Topology.unloadStandardBonds()
+
 
 def pattern_from_multiline(multiline, pattern):
     """Return only lines that contain the pattern
@@ -317,11 +395,6 @@ def test_peptide_system_integrity():
 
     # Make sure there are no differences between the particles in each system
     assert original_system == after_driver
-
-
-
-
-
 
 
 @pytest.mark.skip(reason="Still creating input file.")


### PR DESCRIPTION
Why:

A bug was detected inside the SelfAdjustedMixtureSampling class.
The index of the titration group defaults to 0 in many places for
convenience. The user supplied group_index inside of the `adapt_zetas`
function was ignored when retrieving current weights. This has now been
fixed, and a test has been added of the use case that originally
captured the broken behavior, and maintain correctness in the future.

This error might have gone undiscovered in the past due to SAMS not
frequently being used on a residue other than the first titration group.
Typical past use case was SAMS on one ligand/amino acid in solvent.

This change addresses the need by:

* Fix group_index in SelfAdjustedMixtureSampling.adapt_zetas call to
`get_gk`.
* Add test where SAMS calibration is performed on a residue other than
the first residue in the system.