### PR TITLE
Checkpointing feature and pH fix [WIP]

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - seaborn
     - matplotlib
     - pandas
+    - beautifulsoup4 # for deserialization of html tables
 
   run:
     - python
@@ -47,6 +48,7 @@ requirements:
     - seaborn
     - matplotlib
     - pandas
+    - beautifulsoup4 # for deserialization of html tables
 
 test:
   requires:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - pymbar
     - seaborn
     - matplotlib
+    - pandas
 
   run:
     - python
@@ -45,6 +46,7 @@ requirements:
     - pymbar
     - seaborn
     - matplotlib
+    - pandas
 
 test:
   requires:

--- a/protons/app/__init__.py
+++ b/protons/app/__init__.py
@@ -7,7 +7,7 @@ from simtk.openmm.app import *
 from .topology import Topology
 from .calibration import SelfAdjustedMixtureSampling
 from .simulation import ConstantPHCalibration, ConstantPHSimulation
-from .driver import ForceFieldProtonDrive, AmberProtonDrive
+from .driver import ForceFieldProtonDrive, AmberProtonDrive, NCMCProtonDrive
 from .proposals import UniformProposal, DoubleProposal, CategoricalProposal
 from .integrators import GBAOABIntegrator
 from .modeller import Modeller

--- a/protons/app/driver.py
+++ b/protons/app/driver.py
@@ -586,9 +586,7 @@ class _TitrationState:
     def __eq__(self, other):
         """Compare the equality of two _TitrationState objects."""
         if not isinstance(other, _TitrationState):
-            raise TypeError("Can not compare equality between _TitrationState and {}".format(type(other)))
-
-        import pytest
+            return False
 
         float_atol = 1.e-10
         if not np.isclose(self._target_weight, other._target_weight, rtol=0.0, atol=float_atol):
@@ -623,12 +621,7 @@ class _TitrationState:
                         return False
 
         # Everything that was checked seems equal.
-        pytest.set_trace()
         return True
-
-
-
-
 
 
 class _BaseDrive(metaclass=ABCMeta):
@@ -821,6 +814,21 @@ class NCMCProtonDrive(_BaseDrive):
                 self.forces_to_update.append(force)
 
         return
+
+    def serialize_state(self):
+        """Store the state of residues handled by the drive as xml.
+
+        Returns
+        -------
+        str - xml representation of the residues inside of the drive.
+        """
+        xmltree = etree.Element("NCMCProtonDrive")
+        for res in self.titrationGroups:
+            xmltree.append(res.serialize())
+
+        return etree.tostring(xmltree, encoding="utf-8", pretty_print=True)
+
+
 
     @property
     def titrationStates(self):

--- a/protons/app/driver.py
+++ b/protons/app/driver.py
@@ -833,6 +833,8 @@ class NCMCProtonDrive(_BaseDrive):
 
     def add_residues_from_serialized_xml(self, xmltree):
         """Add residues from previously serialized residues."""
+        if type(xmltree) == str:
+            xmltree = etree.fromstring(xmltree)
         drive_xml = xmltree.xpath("/NCMCProtonDrive")[0]
         for res in drive_xml.xpath("TitratableResidue"):
             self.titrationGroups.append(_TitratableResidue.from_serialized_xml(res))

--- a/protons/app/ligands.py
+++ b/protons/app/ligands.py
@@ -118,7 +118,7 @@ class _State(object):
     """
     Private class representing a template of a single isomeric state of the molecule.
     """
-    def __init__(self, index, log_population, g_k, net_charge, atom_list):
+    def __init__(self, index, log_population, g_k, net_charge, atom_list, pH):
         """
 
         Parameters
@@ -143,6 +143,7 @@ class _State(object):
         self.proton_count = -1
         for atom in atom_list:
             self.atoms[atom] = None
+        self.pH = pH
 
     def validate(self):
         """
@@ -215,10 +216,9 @@ class _State(object):
         self.proton_count = int(self.net_charge) - min_charge
 
     def __str__(self):
-        return '<State index="{index}" ' \
-               'log_population="{log_population}"' \
-               ' g_k="{g_k}"' \
-               ' proton_count="{proton_count}"/>'.format(**self.__dict__)
+        return """<State index="{index}" log_population="{log_population}" g_k="{g_k}" proton_count="{proton_count}">
+                <Condition pH="{pH}" log_population="{log_population}" temperature_kelvin="298.15"/>
+                </State>""".format(**self.__dict__)
 
     __repr__ = __str__
 
@@ -867,7 +867,8 @@ class _TitratableForceFieldCompiler(object):
                               state['log_population'],
                               state['epik_penalty'],
                               net_charge,
-                              self._atom_names
+                              self._atom_names,
+                              state['pH']
                               )
             for xml_atom in state['ffxml'].xpath('/ForceField/Residues/Residue/Atom'):
                 template.set_atom(_Atom(xml_atom.attrib['name'], xml_atom.attrib['type'], xml_atom.attrib['charge']))
@@ -1063,7 +1064,7 @@ def generate_protons_ffxml(inputmae, outputffxml, tmpdir=None, remove_temp_files
         elif "r_epik_State_Penalty" in line:
             # Next line contains epik state penalty
             store = "log_population"
-            isomers[isomer_index] = dict()
+            isomers[isomer_index] = dict(pH=pH)
 
         elif "i_epik_Tot_Q" in line:
             # Next line contains charge

--- a/protons/app/pka.py
+++ b/protons/app/pka.py
@@ -1,5 +1,7 @@
 # coding=utf-8
-"""Objects for calculation of state populations based on pKa."""
+"""Objects for calculation of state populations based on pKa. This library is specific to Amber 10 constant-pH force field amino acid residues,
+though not all of those residues are included here.
+"""
 import abc
 
 
@@ -7,8 +9,6 @@ class PopulationCalculator(metaclass=abc.ABCMeta):
     """
     Abstract base class for determining state populations from a pH curve
     """
-    __metaclass__ = abc.ABCMeta
-
     @abc.abstractmethod
     def populations(self):
         """ Return population of each state of the amino acid.
@@ -17,10 +17,10 @@ class PopulationCalculator(metaclass=abc.ABCMeta):
         -------
         list of float
         """
-        return NotImplemented
+        raise NotImplemented("This is an abstract class.")
 
 
-class Histidine(PopulationCalculator):
+class HistidineType(PopulationCalculator):
     """
     Amber constant-pH HIP residue state weights at given pH
     """
@@ -28,8 +28,8 @@ class Histidine(PopulationCalculator):
     pka_e = 7.1
 
     def __init__(self, pH):
-        self.kd = pow(10.0, pH - Histidine.pka_d)
-        self.ke = pow(10.0, pH - Histidine.pka_e)
+        self.kd = pow(10.0, pH - HistidineType.pka_d)
+        self.ke = pow(10.0, pH - HistidineType.pka_e)
 
     def hip_concentration(self):
         """
@@ -58,11 +58,14 @@ class Histidine(PopulationCalculator):
         return [self.hip_concentration(), self.hid_concentration(), self.hie_concentration()]
 
 
-class Aspartic4(PopulationCalculator):
+HIP = HistidineType
+
+
+class SynAntiAcidType(PopulationCalculator):
     """
-    Amber constant-pH AS4 residue state weights at given pH
+    Amber constant-pH AS4/GL4 syn/anti residue state weights at given pH
     """
-    pka = 4.0
+    pka = 0.0
 
     def __init__(self, pH):
         self.k = pow(10.0, pH - self.pka)
@@ -89,18 +92,36 @@ class Aspartic4(PopulationCalculator):
         return [self.deprotonated_concenration(), acid, acid, acid, acid]
 
 
-class Glutamic4(Aspartic4):
-    """
-    Amber constant-pH GL4 residue state weights at given pH
-    """
+class AS4(SynAntiAcidType):
+    """Aspartic acid with syn/anti protons."""
+    pka = 4.0
+
+
+class GL4(SynAntiAcidType):
+    """Glutamic acid with syn/anti protons"""
     pka = 4.4
 
 
-class Lysine(Aspartic4):
+class BasicType(PopulationCalculator):
     """
-    Amber constant-pH LYS residue state weights at given pH
+    Amber constant-pH basic residue (e.g. LYS) state weights at given pH
     """
     pka = 10.4
+
+    def __init__(self, pH):
+        self.k = pow(10.0, pH - self.pka)
+
+    def protonated_concentration(self):
+        """
+        Concentration of protonated form
+        """
+        return 1.0/(self.k + 1.0)
+
+    def deprotonated_concenration(self):
+        """
+        Concentration of deprotonated form
+        """
+        return self.k / (self.k + 1.0)
 
     def populations(self):
         """
@@ -111,15 +132,29 @@ class Lysine(Aspartic4):
         return [self.protonated_concentration(), self.deprotonated_concenration()]
 
 
-class Tyrosine(Lysine):
-    """
-    Amber constant-pH TYR residue state weights at given pH
-    """
+class LYS(BasicType):
+    """Lysine residue"""
+    pka = 10.4
+
+
+class TYR(BasicType):
+    """Tyrosine residue."""
     pka = 9.6
 
 
-class Cysteine(Lysine):
+class CYS(BasicType):
     """
-    Amber constant-pH CYS residue state weights at given pH
+    Cysteine residue.
     """
     pka = 8.5
+
+
+available_pkas = {
+    "AS4": AS4,
+    "GL4": GL4,
+    "CYS": CYS,
+    "HIP": HIP,
+    "HIS": HIP,
+    "TYR": TYR,
+    "LYS": LYS
+}

--- a/protons/app/titrationreporter.py
+++ b/protons/app/titrationreporter.py
@@ -12,6 +12,7 @@ from simtk.unit import elementary_charge
 # ion names from ions xml files in protons.
 _solvent_names = ["HOH", "H20", "WAT", "SOL", "TIP3", "TP3", "Li+", "Na+", "K+", "Rb+", "Cs+", "F-", "Cl-", "Br-", "I-"]
 
+
 class TitrationReporter:
     """TitrationReporter outputs protonation states of residues in the system to a netCDF4 file."""
 

--- a/protons/tests/test_explicit.py
+++ b/protons/tests/test_explicit.py
@@ -517,5 +517,27 @@ class TestForceFieldImidazoleExplicitpHAdjusted(object):
         driver.adjust_to_ph(7.4)
         x = driver.titrationGroups[0].serialize()
         y = app.driver._TitratableResidue.from_serialized_xml(x)
-        pytest.set_trace()
+
+    def test_imidazole_serialization_correctness(self):
+        """
+        Test the correctness of a deserialized imidazole titration group.
+        """
+        testsystem = self.setup_imidazole_explicit()
+        compound_integrator = create_compound_gbaoab_integrator(testsystem)
+        driver = ForceFieldProtonDrive(testsystem.temperature, testsystem.topology, testsystem.system,
+                                       testsystem.forcefield, testsystem.ffxml_filename,
+                                       pressure=testsystem.pressure,
+                                       perturbations_per_trial=0)
+        platform = openmm.Platform.getPlatformByName(self.default_platform)
+        context = openmm.Context(testsystem.system, compound_integrator, platform)
+        context.setPositions(testsystem.positions)  # set to minimized positions
+        context.setVelocitiesToTemperature(testsystem.temperature)
+        driver.attach_context(context)
+        driver.adjust_to_ph(7.4)
+        before_group = driver.titrationGroups[0]
+        x = before_group.serialize()
+        after_group = app.driver._TitratableResidue.from_serialized_xml(x)
+        assert before_group == after_group, "The deserialized group does not match what was serialized."
+
+
 

--- a/protons/tests/test_explicit.py
+++ b/protons/tests/test_explicit.py
@@ -482,4 +482,20 @@ class TestForceFieldImidazoleExplicitpHAdjusted(object):
         with pytest.raises(ValueError) as exception_info:
             driver.adjust_to_ph(4.0)
 
+    def test_imidazole_instantaneous_serialize(self):
+        """
+        Test the serialization of an imidazole titration group.
+        """
+        testsystem = self.setup_imidazole_explicit()
+        compound_integrator = create_compound_gbaoab_integrator(testsystem)
+        driver = ForceFieldProtonDrive(testsystem.temperature, testsystem.topology, testsystem.system,
+                                       testsystem.forcefield, testsystem.ffxml_filename, pressure=testsystem.pressure,
+                                       perturbations_per_trial=0)
+        platform = openmm.Platform.getPlatformByName(self.default_platform)
+        context = openmm.Context(testsystem.system, compound_integrator, platform)
+        context.setPositions(testsystem.positions)  # set to minimized positions
+        context.setVelocitiesToTemperature(testsystem.temperature)
+        driver.attach_context(context)
+        driver.adjust_to_ph(7.4)
+        x = driver.titrationGroups[0].serialize()
 

--- a/protons/tests/test_explicit.py
+++ b/protons/tests/test_explicit.py
@@ -418,6 +418,22 @@ class TestAmberPeptide(object):
         compound_integrator.step(10)  # MD
         driver.update(UniformProposal(), nattempts=10)  # protonation
 
+    def test_peptide_serialization(self):
+        """
+        Set up a peptide system and serialize it.
+        """
+        testsystem = self.setup_edchky_explicit()
+
+        compound_integrator = create_compound_gbaoab_integrator(testsystem)
+        driver = AmberProtonDrive(testsystem.temperature, testsystem.topology, testsystem.system,
+                                  testsystem.cpin_filename, pressure=testsystem.pressure, perturbations_per_trial=2)
+        platform = openmm.Platform.getPlatformByName(self.default_platform)
+        context = openmm.Context(testsystem.system, compound_integrator, platform)
+        context.setPositions(testsystem.positions)  # set to minimized positions
+        context.setVelocitiesToTemperature(testsystem.temperature)
+        driver.attach_context(context)
+        x = driver.serialize_state()
+
 
 class TestForceFieldImidazoleExplicitpHAdjusted(object):
     """Tests for pH adjusting imidazole weights in explict solvent (TIP3P)"""

--- a/protons/tests/test_explicit.py
+++ b/protons/tests/test_explicit.py
@@ -499,3 +499,23 @@ class TestForceFieldImidazoleExplicitpHAdjusted(object):
         driver.adjust_to_ph(7.4)
         x = driver.titrationGroups[0].serialize()
 
+    def test_imidazole_instantaneous_deserialize(self):
+        """
+        Test the deserialization of an imidazole titration group.
+        """
+        testsystem = self.setup_imidazole_explicit()
+        compound_integrator = create_compound_gbaoab_integrator(testsystem)
+        driver = ForceFieldProtonDrive(testsystem.temperature, testsystem.topology, testsystem.system,
+                                       testsystem.forcefield, testsystem.ffxml_filename,
+                                       pressure=testsystem.pressure,
+                                       perturbations_per_trial=0)
+        platform = openmm.Platform.getPlatformByName(self.default_platform)
+        context = openmm.Context(testsystem.system, compound_integrator, platform)
+        context.setPositions(testsystem.positions)  # set to minimized positions
+        context.setVelocitiesToTemperature(testsystem.temperature)
+        driver.attach_context(context)
+        driver.adjust_to_ph(7.4)
+        x = driver.titrationGroups[0].serialize()
+        y = app.driver._TitratableResidue.from_serialized_xml(x)
+        pytest.set_trace()
+

--- a/protons/tests/test_pkas.py
+++ b/protons/tests/test_pkas.py
@@ -1,7 +1,7 @@
 """Tests for pH curve calculation"""
 from __future__ import print_function
 
-from protons.app.pka import Histidine, Lysine, Tyrosine, Aspartic4, Cysteine, Glutamic4
+from protons.app.pka import HIP as Histidine, TYR as Tyrosine, AS4 as Aspartic4, CYS as Cysteine, GL4 as Glutamic4, LYS as Lysine
 from numpy import linspace
 from pytest import approx
 

--- a/protons/tests/test_simulation.py
+++ b/protons/tests/test_simulation.py
@@ -198,7 +198,6 @@ class TestConstantPHCalibration:
 
         assert simulation2.current_adaptation == 6, "The resumed calibration does not have the right adaptation_index"
 
-        import pytest; pytest.set_trace()
 
     def test_create_constantphcalibration_with_reporters(self):
         """Test running a calibration using constant-pH with reporters."""

--- a/protons/tests/test_simulation.py
+++ b/protons/tests/test_simulation.py
@@ -135,6 +135,71 @@ class TestConstantPHCalibration:
         # Adapt the weights using binary update.
         simulation.adapt()
 
+    def test_create_constantphcalibration_resume(self):
+        """Test running a calibration using constant-pH."""
+        pdb = app.PDBxFile(get_test_data('glu_ala_his-solvated-minimized-renamed.cif', 'testsystems/tripeptides'))
+        forcefield = app.ForceField('amber10-constph.xml', 'ions_tip3p.xml', 'tip3p.xml')
+
+        system = forcefield.createSystem(pdb.topology, nonbondedMethod=app.PME,
+                                         nonbondedCutoff=1.0 * unit.nanometers, constraints=app.HBonds, rigidWater=True,
+                                         ewaldErrorTolerance=0.0005)
+
+        temperature = 300 * unit.kelvin
+        integrator = GBAOABIntegrator(temperature=temperature, collision_rate=1.0 / unit.picoseconds,
+                                      timestep=2.0 * unit.femtoseconds, constraint_tolerance=1.e-7, external_work=False)
+        ncmcintegrator = GBAOABIntegrator(temperature=temperature, collision_rate=1.0 / unit.picoseconds,
+                                          timestep=2.0 * unit.femtoseconds, constraint_tolerance=1.e-7,
+                                          external_work=True)
+
+        compound_integrator = mm.CompoundIntegrator()
+        compound_integrator.addIntegrator(integrator)
+        compound_integrator.addIntegrator(ncmcintegrator)
+        pressure = 1.0 * unit.atmosphere
+
+        system.addForce(mm.MonteCarloBarostat(pressure, temperature))
+        driver = ForceFieldProtonDrive(temperature, pdb.topology, system, forcefield, ['amber10-constph.xml'],
+                                       pressure=pressure,
+                                       perturbations_per_trial=0)
+        simulation = app.ConstantPHCalibration(pdb.topology, system, compound_integrator, driver, group_index=1,
+                                               platform=self._default_platform)
+        simulation.context.setPositions(pdb.positions)
+        simulation.context.setVelocitiesToTemperature(temperature)
+        simulation.step(1)
+        # Update the titration states using the uniform proposal
+        simulation.update(1)
+        # Adapt the weights using binary update, a few times just to rack up the counters.
+        for x in range(5):
+            simulation.adapt()
+        # retrieve the samsProperties
+        samsProperties = simulation.export_samsProperties()
+
+        integrator2 = GBAOABIntegrator(temperature=temperature, collision_rate=1.0 / unit.picoseconds,
+                                      timestep=2.0 * unit.femtoseconds, constraint_tolerance=1.e-7, external_work=False)
+        ncmcintegrator2 = GBAOABIntegrator(temperature=temperature, collision_rate=1.0 / unit.picoseconds,
+                                          timestep=2.0 * unit.femtoseconds, constraint_tolerance=1.e-7,
+                                          external_work=True)
+        compound_integrator2 = mm.CompoundIntegrator()
+        compound_integrator2.addIntegrator(integrator2)
+        compound_integrator2.addIntegrator(ncmcintegrator2)
+
+        # Make a new calibration and do another step, ignore the state for this example
+        simulation2 = app.ConstantPHCalibration(pdb.topology, system, compound_integrator2, driver, group_index=1,
+                                               platform=self._default_platform, samsProperties=samsProperties)
+
+        assert simulation2.stage == simulation.stage
+        # get going then
+        simulation2.context.setPositions(pdb.positions)
+        simulation2.context.setVelocitiesToTemperature(temperature)
+        simulation2.step(1)
+        # Update the titration states using the uniform proposal
+        simulation2.update(1)
+        # Adapt the weights using binary update.
+        simulation2.adapt()
+
+        assert simulation2.current_adaptation == 6, "The resumed calibration does not have the right adaptation_index"
+
+        import pytest; pytest.set_trace()
+
     def test_create_constantphcalibration_with_reporters(self):
         """Test running a calibration using constant-pH with reporters."""
         pdb = app.PDBxFile(get_test_data('glu_ala_his-solvated-minimized-renamed.cif', 'testsystems/tripeptides'))

--- a/protons/tests/testsystems/imidazole_explicit/protons-imidazole-ph-feature.xml
+++ b/protons/tests/testsystems/imidazole_explicit/protons-imidazole-ph-feature.xml
@@ -1,0 +1,63 @@
+<ForceField>
+  <Residues>
+    <Residue name="LIG">
+      <Atom name="C1" type="cc" charge="-0.2617"/>
+      <Atom name="C2" type="cd" charge="0.2909"/>
+      <Atom name="N3" type="na" charge="-0.3221"/>
+      <Atom name="C4" type="cc" charge="0.3815"/>
+      <Atom name="N5" type="na" charge="-0.6658"/>
+      <Atom name="H6" type="h4" charge="0.042"/>
+      <Atom name="H7" type="h5" charge="0.0598"/>
+      <Atom name="H9" type="h4" charge="0.1759"/>
+      <Atom name="H10" type="hn" charge="0.2994"/>
+      <Atom name="H8" type="hn" charge="0.0"/>
+      <Bond atomName1="C1" atomName2="C2"/>
+      <Bond atomName1="C1" atomName2="H9"/>
+      <Bond atomName1="C1" atomName2="N3"/>
+      <Bond atomName1="C2" atomName2="H6"/>
+      <Bond atomName1="C2" atomName2="N5"/>
+      <Bond atomName1="C4" atomName2="N3"/>
+      <Bond atomName1="H10" atomName2="N3"/>
+      <Bond atomName1="C4" atomName2="N5"/>
+      <Bond atomName1="C4" atomName2="H7"/>
+      <Bond atomName1="H8" atomName2="N5"/>
+      <Protons number_of_states="2">
+        <State index="0" g_k="0.2174" proton_count="0">
+          <Condition pH="7.4" log_population="-0.36692927332637043" temperature_kelvin="298.15"  ionic_strength_mM="150"/>
+          <Atom name="C1" type="cc" charge="-0.2617"/>
+          <Atom name="C2" type="cd" charge="0.2909"/>
+          <Atom name="N3" type="na" charge="-0.3221"/>
+          <Atom name="C4" type="cc" charge="0.3815"/>
+          <Atom name="N5" type="na" charge="-0.6658"/>
+          <Atom name="H6" type="h4" charge="0.042"/>
+          <Atom name="H7" type="h5" charge="0.0598"/>
+          <Atom name="H9" type="h4" charge="0.1759"/>
+          <Atom name="H10" type="hn" charge="0.2994"/>
+          <Atom name="H8" type="hn" charge="0.0"/>
+        </State>
+        <State index="1" log_population="-1.1802835365093416" g_k="0.6993" proton_count="1">
+          <Condition pH="7.4" log_population="-0.36692927332637043" temperature_kelvin="298.15" ionic_strength_mM="150" />
+          <Atom name="C1" type="cc" charge="-0.0006"/>
+          <Atom name="C2" type="cd" charge="-0.0006"/>
+          <Atom name="N3" type="na" charge="-0.4999"/>
+          <Atom name="C4" type="cc" charge="0.2042"/>
+          <Atom name="N5" type="na" charge="-0.4999"/>
+          <Atom name="H6" type="h4" charge="0.2427"/>
+          <Atom name="H7" type="h5" charge="0.2679"/>
+          <Atom name="H9" type="h4" charge="0.2427"/>
+          <Atom name="H10" type="hn" charge="0.5217"/>
+          <Atom name="H8" type="hn" charge="0.5217"/>
+        </State>
+      </Protons>
+    </Residue>
+  </Residues>
+  <PeriodicTorsionForce>
+    <Improper type1="cc" type2="cd" type3="h4" type4="na" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
+    <Improper type1="cd" type2="cc" type3="h4" type4="nd" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
+    <Improper type1="na" type2="cc" type3="cc" type4="hn" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
+    <Improper type1="cc" type2="h5" type3="na" type4="nd" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
+    <Improper type1="cd" type2="cc" type3="h4" type4="na" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
+    <Improper type1="cc" type2="h5" type3="na" type4="na" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
+    <Improper type1="na" type2="cc" type3="cd" type4="hn" periodicity1="2" phase1="3.141592653589793" k1="4.6024"/>
+  </PeriodicTorsionForce>
+</ForceField>


### PR DESCRIPTION
This PR adds a checkpointing mechanism. This involves serialization of proton drives into xml. 

It also includes a fixed version of the pH correction feature which I ran into during serialization. It contained a bug that resulted in NaN values that weren't picked up.

Tasks:

- [x] Serialization of `_TitratableResidue` data structure
- [x] Serializaton of `_TitrationState` data structure
- [x] Deserialization of `_TitratableResidue` data structure
- [x] "Running the code" tests
- [x] Deserialization of `_TitrationState` data structure
- [x] (De)serialization of protondrive as a whole, including properties, and titration states and residues.
- [x] Unit tests for before/after serialization consistency of objects, ensuring that the simulation properly gets resumed

Also includes
- [x] bugfix for pH code that is necessary to get deserialization working.
