### PR TITLE
Implement maintaining charge neutrality through saltswap

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - matplotlib
     - pandas
     - beautifulsoup4 # for deserialization of html tables
+    - saltswap >=0.5.1 # for counterion coupling
 
   run:
     - python
@@ -48,6 +49,7 @@ requirements:
     - seaborn
     - matplotlib
     - pandas
+    - saltswap >=0.5.1 # for counterion coupling
     - beautifulsoup4 # for deserialization of html tables
 
 test:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - matplotlib
     - pandas
     - beautifulsoup4 # for deserialization of html tables
-    - saltswap >=0.5.1 # for counterion coupling
+    - saltswap >=0.5.2 # for counterion coupling
 
   run:
     - python
@@ -49,7 +49,7 @@ requirements:
     - seaborn
     - matplotlib
     - pandas
-    - saltswap >=0.5.1 # for counterion coupling
+    - saltswap >=0.5.2 # for counterion coupling
     - beautifulsoup4 # for deserialization of html tables
 
 test:

--- a/protons/app/driver.py
+++ b/protons/app/driver.py
@@ -931,6 +931,11 @@ class NCMCProtonDrive(_BaseDrive):
 
         self.swapper = swapper
 
+        nwat, ncat, nani = swapper.get_identity_counts()
+
+        # The excess amount of ions, positive if cations, negative if more anions
+        self.excess_ions = ncat - nani
+
         self._ion_parameters = {0: self.swapper.water_parameters,
                                 1: self.swapper.cation_parameters,
                                 2: self.swapper.anion_parameters
@@ -1633,7 +1638,6 @@ class NCMCProtonDrive(_BaseDrive):
                     f_params[force_index]['exceptions'].append(exc_dict)
 
         self.titrationGroups[titration_group_index][titration_state_index].forces = f_params
-
 
 
     def _perform_ncmc_protocol(self, titration_group_indices, initial_titration_states, final_titration_states, salt_residue_indices=None, salt_states=None):

--- a/protons/app/driver.py
+++ b/protons/app/driver.py
@@ -1772,7 +1772,8 @@ class NCMCProtonDrive(_BaseDrive):
         final_titration_states, titration_group_indices, log_p_residue_proposal = proposal.propose_states(self, residue_pool_indices)
         if self.swapper is not None:
             net_charge_difference = self._calculate_charge_differences(initial_titration_states, final_titration_states, titration_group_indices)
-
+            saltswap_residue_indices, saltswap_parameter_pairs, salt_proposal_log_ratio = self.swap_proposal.propose_swaps(self, net_charge_difference)
+            
         try:
             # Compute work for switching to new protonation states.
 

--- a/protons/app/driver.py
+++ b/protons/app/driver.py
@@ -1850,7 +1850,8 @@ class NCMCProtonDrive(_BaseDrive):
             if initial_titration_states != final_titration_states:
                 self.nattempted += 1
             # Accept or reject with Metropolis criteria.
-            if (log_P_accept > 0.0) or (random.random() < math.exp(log_P_accept)):
+            accept_move = self._accept_reject(log_P_accept)
+            if accept_move:
                 # Accept.
                 if initial_titration_states != final_titration_states:
                     self.naccepted += 1
@@ -1929,6 +1930,10 @@ class NCMCProtonDrive(_BaseDrive):
             self.compound_integrator.setCurrentIntegrator(0)
 
         return
+
+    def _accept_reject(self, log_P_accept) -> bool:
+        """Perform acceptance/rejection check according to the Metropolis-Hastings acceptance criterium."""
+        return (log_P_accept > 0.0) or (random.random() < math.exp(log_P_accept))
 
     def _get_acceptance_probability(self):
         """

--- a/protons/app/driver.py
+++ b/protons/app/driver.py
@@ -1743,7 +1743,6 @@ class NCMCProtonDrive(_BaseDrive):
             self.titrationGroups[titration_group_index].state = final_titration_states[titration_group_index]
 
         # Extracting the final state's weight.
-        # todo do the different salt states have separate weights, or should they all be weighted the same?
         g_final = 0
         for titration_group_index, (titration_group, titration_state_index) in enumerate(zip(self.titrationGroups, self.titrationStates)):
             titration_state = titration_group[titration_state_index]
@@ -1828,7 +1827,6 @@ class NCMCProtonDrive(_BaseDrive):
                 # Only perform NCMC when the proposed state is different from the current state
                 if initial_titration_states != final_titration_states:
                     # Run NCMC integration.
-                    # TODO Insert ion changes from the saltswap proposal as arguments to this function.
                     work = self._perform_ncmc_protocol(titration_group_indices, initial_titration_states, final_titration_states)
                 else:
                     work = 0.0

--- a/protons/app/driver.py
+++ b/protons/app/driver.py
@@ -932,8 +932,9 @@ class NCMCProtonDrive(_BaseDrive):
         self.swapper = swapper
 
         self._ion_parameters = {0: self.swapper.water_parameters,
-                      1: self.swapper.cation_parameters,
-                      2: self.swapper.anion_parameters}
+                                1: self.swapper.cation_parameters,
+                                2: self.swapper.anion_parameters
+                                }
 
         if proposal is not None:
             self.swap_proposal = proposal
@@ -1678,14 +1679,12 @@ class NCMCProtonDrive(_BaseDrive):
         ncmc_integrator = self.ncmc_integrator
         update_salt = False
 
-        if salt_residue_indices is not None:
-            if salt_states is None:
-                raise ValueError("Need to provide states of the salt changes when specifying salt indices.")
-        elif salt_states is not None:
-            if salt_residue_indices is None:
-                raise ValueError("Need to specify the salt_residue_indices when specifying salt state changes.")
-        elif salt_residue_indices is not None and salt_states is not None:
+        if salt_residue_indices is not None and salt_states is not None:
             update_salt = True
+        elif salt_residue_indices is not None and salt_states is None:
+                raise ValueError("Need to provide states of the salt changes when specifying salt indices.")
+        elif salt_states is not None and salt_residue_indices is None:
+                raise ValueError("Need to specify the salt_residue_indices when specifying salt state changes.")
 
         # Reset integrator statistics
         try:

--- a/protons/app/driver.py
+++ b/protons/app/driver.py
@@ -16,7 +16,7 @@ from simtk import unit
 from simtk import openmm as mm
 import saltswap
 from saltswap.swapper import Swapper
-from .proposals import _StateProposal, _SaltSwapProposal, UniformSwapProposal
+from .proposals import _StateProposal, SaltSwapProposal, UniformSwapProposal
 from .topology import Topology
 from .pka import available_pkas
 from simtk.openmm import app
@@ -805,7 +805,7 @@ class NCMCProtonDrive(_BaseDrive):
         # A dict of ion parameters, indexed by integers. Set from the swapper in attach_swapper.
         self._ion_parameters = None
 
-        # The method used to select ions. Should be a subclass of _SaltSwapProposal
+        # The method used to select ions. Should be a subclass of SaltSwapProposal
         # This variable is set using the `attach_swapper` method.
         self.swap_proposal = None
 
@@ -918,7 +918,7 @@ class NCMCProtonDrive(_BaseDrive):
         for force_index, force in enumerate(self.forces_to_update):
             force.updateParametersInContext(self.context)
 
-    def attach_swapper(self, swapper: Swapper, proposal: _SaltSwapProposal=None):
+    def attach_swapper(self, swapper: Swapper, proposal: SaltSwapProposal=None):
         """
         Provide a saltswapper to enable maintaining charge neutrality.
 

--- a/protons/app/driver.py
+++ b/protons/app/driver.py
@@ -925,6 +925,9 @@ class NCMCProtonDrive(_BaseDrive):
         Parameters
         ----------
         swapper - a saltswap.Swapper object that is used for ion manipulation and bookkeeping.
+        proposal - optional, a SaltSwapProposal derived class that is used to select ions. If not provided it uses
+        the UniformSwapProposal
+
         """
         if not isinstance(swapper, Swapper):
             raise TypeError("Please provide a Swapper object.")

--- a/protons/app/proposals.py
+++ b/protons/app/proposals.py
@@ -5,7 +5,7 @@ from .logger import log
 import copy
 import random
 import numpy as np
-
+from scipy.misc import comb
 
 class _StateProposal(metaclass=ABCMeta):
     """An abstract base class describing the common public interface of residue selection moves."""
@@ -159,3 +159,253 @@ class CategoricalProposal(_StateProposal):
         return final_titration_states, titration_group_indices, 0.0
 
 
+class _SaltSwapProposal:
+    """This class is a baseclass for selecting water molecules or ions to maintain charge neutrality."""
+
+    def propose_swaps(self, drive, net_charge_difference):
+        """Select a series of water molecules/ions to swap.
+
+        Parameters
+        ----------
+
+        drive - a ProtonDrive object with a swapper attached.
+        net_charge_difference - int, the total charge that needs to be countered by ions.
+
+        Nota bene
+        ---------
+        The net charge difference will have the opposite charge of the ions that will be added to the system,
+        such that the resulting total charge change will be 0.
+
+        Returns
+        -------
+        list(int) - indices of water molecule in saltswap that are swapped
+        list(tuple(dict,dict),) -  list of tuples with (initial, final) parameters of the water molecule/ion as dict, one tuple for each requested swap
+        float - log (probability of reverse proposal)/(probability of forward proposal)
+        """
+
+        return list(), list(), float()
+
+
+class UniformSwapProposal(_SaltSwapProposal):
+    """Uniformly selects as many water/ions as needed from the array of available waters/ions."""
+
+    def __init__(self):
+        """Instantiate a UniformSwapProposal."""
+        pass
+
+    @staticmethod
+    def _select_ion_water_swaps(drive, charge_to_counter):
+        """Select ions or water molecule swap procedure to facilitate maintaining charge neutrality while changing protonation states.
+
+        Notes
+        -----
+        Technically, for charge differences of 2 we could change one anion into a cation or vice versa.
+        This code would instead remove one anion, and change one water into a cation.
+
+        Parameters
+        ----------
+        drive - a ProtonDrive object
+        charge_to_counter - the total difference in charge that needs to be countered.
+
+        Returns
+        -------
+        dict(wat2cat, wat2ani, cat2wat, ani2wat)
+
+        """
+
+        # Note that we don't allow for direct transitions between ions of different charge.
+        swaps = dict(wat2cat=0, wat2ani=0, cat2wat=0, ani2wat=0)
+        excess_ions = int(drive.excess_ions)  # copy
+
+        while abs(charge_to_counter) > 0:
+
+            # A net amount of cations were previously added to the system
+            if excess_ions > 0:
+                charge_to_counter, excess_ions = UniformSwapProposal._swap_excess_cations(charge_to_counter, excess_ions, swaps)
+
+            # No additional ions were previously added by the swapper.
+            elif excess_ions == 0:
+                charge_to_counter, excess_ions = UniformSwapProposal._swap_no_excess_ions(charge_to_counter, excess_ions, swaps)
+
+            # A net amount of anions were previously added to the system
+            elif excess_ions < 0:
+                charge_to_counter, excess_ions = UniformSwapProposal._swap_excess_anions(charge_to_counter, excess_ions, swaps)
+
+        return swaps
+
+    @staticmethod
+    def _swap_excess_anions(charge_to_counter, net_ions, swaps):
+        """Adds a single unit of charge swap in the case of excess anions"""
+
+        # Need to counter positive charge by adding anion
+        if charge_to_counter > 0:
+            swaps['wat2ani'] += 1
+            # One negative charge was added
+            net_ions -= 1
+            # One positive charge was countered
+            charge_to_counter -= 1
+        # Need to counter negative charge by removing anion
+        elif charge_to_counter < 0:
+            swaps['ani2wat'] += 1
+            # One negative charge was removed
+            net_ions += 1
+            # One negative charge was countered
+            charge_to_counter += 1
+        return charge_to_counter, net_ions
+
+    @staticmethod
+    def _swap_no_excess_ions(charge_to_counter, net_ions, swaps):
+        """Add a neutralizing swap operation in the case of no excess ions."""
+        # Need to counter positive charge by adding anion
+        if charge_to_counter > 0:
+            swaps['wat2ani'] += 1
+            # One negative charge was added
+            net_ions -= 1
+            # One positive charge was countered
+            charge_to_counter -= 1
+        # Need to counter negative charge by adding cation
+        elif charge_to_counter < 0:
+            swaps['wat2cat'] += 1
+            # One positive charge was added
+            net_ions += 1
+            # One negative charge was countered
+            charge_to_counter += 1
+
+        return charge_to_counter, net_ions
+
+    @staticmethod
+    def _swap_excess_cations(charge_to_counter, net_ions, swaps):
+        """Add a swap of water/ions in the case of excess cations."""
+        # Need to counter positive charge by removing cation
+        if charge_to_counter > 0:
+            swaps['cat2wat'] += 1
+            # One positive charge was removed
+            net_ions -= 1
+            # One positive charge was countered
+            charge_to_counter -= 1
+        # Need to counter negative charge by adding cation
+        elif charge_to_counter < 0:
+            swaps['wat2cat'] += 1
+            # One positive charge was added
+            net_ions += 1
+            # One negative charge was countered
+            charge_to_counter += 1
+
+        return charge_to_counter, net_ions
+
+    @staticmethod
+    def _validate_swaps(swaps):
+        """Perform sanity checks. Swaps should only add charge in one direction.
+
+        Raises
+        ------
+        RuntimeError - in case conflicting swaps occur at the same time.
+            The error message will detail what the conflict is.
+        """
+
+        if swaps['wat2cat'] != 0 and swaps['wat2ani'] != 0:
+            raise RuntimeError("Opposing charge ions are added. This is a bug in the code.")
+        elif swaps['cat2wat'] != 0 and swaps['ani2wat'] != 0:
+            raise RuntimeError("Opposing charge ions are removed. This is a bug in the code.")
+        elif swaps['cat2wat'] != 0 and swaps['wat2cat'] != 0:
+            raise RuntimeError("Cations are being added and removed at the same time. This is a bug in the code.")
+        elif swaps['ani2wat'] != 0 and swaps['wat2ani'] != 0:
+            raise RuntimeError("Anions are being added and removed at the same time. This is a bug in the code.")
+
+    def propose_swaps(self, drive, net_charge_difference):
+        """Select a series of water molecules/ions to swap uniformly from all waters/ions.
+
+            Parameters
+            ----------
+
+            drive - a ProtonDrive object with a swapper attached.
+            net_charge_difference - int, the total charge that needs to be countered.
+
+            Returns
+            -------
+            list(int) - indices of water molecule in saltswap that are swapped
+            list(tuple(dict,dict),) -  list of tuples with (initial, final) parameters of the water molecule/ion as dict, one tuple for each requested swap
+            float - log (probability of reverse proposal)/(probability of forward proposal)
+        """
+
+        # Defaults. If no swaps are necessary, this will be all that is needed.
+        saltswap_residue_indices = list()
+        saltswap_parameter_pairs = list()
+        log_ratio = 0.0 # fully symmetrical proposal if no swaps occur.
+
+        # If swaps are needed
+        if net_charge_difference != 0:
+
+            water_params = drive.swapper.water_parameters
+            cation_params = drive.swapper.cation_parameters
+            anion_params = drive.swapper.anion_parameters
+
+            # There is a net charge difference, find which swaps are necessary to compute.
+            swaps = self._select_ion_water_swaps(drive, net_charge_difference)
+
+            # Apply sanity checks
+            UniformSwapProposal._validate_swaps(swaps)
+
+            all_waters = np.where(drive.swapper.stateVector == 0)[0]
+            all_cations = np.where(drive.swapper.stateVector == 1)[0]
+            all_anions = np.where(drive.swapper.stateVector == 2)[0]
+
+
+            # This code should only perform wat2cat OR wat2ani, not both.
+            # The sanity check should prevent the same waters/ions from being selected twice.
+            # individual types of swaps should be completely independent for the purpose of calculating
+            # the proposal probabilities.
+
+            if swaps['wat2cat'] > 0:
+                for water_index in np.random.choice(a=all_waters, size=swaps['wat2cat'], replace=False):
+                    saltswap_residue_indices.append(water_index)
+                    saltswap_parameter_pairs.append(tuple([water_params, cation_params]))
+
+                # Forward: choose m water to change into cations, probability of one pick is
+                # 1.0 / (n_water choose m); e.g. from all waters select m (the wat2cat count).
+                log_p_forward = -np.log(comb(all_waters.size, swaps['wat2cat'], exact=True))
+                # Reverse: choose m cations to change into water, probability of one pick is
+                # 1.0 / (n_cation + m choose m); e.g. from current cations plus m (the wat2cat count), select m
+                log_p_reverse = -np.log(comb(all_cations.size + swaps['wat2cat'], swaps['wat2cat'], exact=True))
+                log_ratio += (log_p_reverse - log_p_forward)
+
+            if swaps['wat2ani'] > 0:
+                for water_index in np.random.choice(a=all_waters, size=swaps['wat2ani'], replace=False):
+                    saltswap_residue_indices.append(water_index)
+                    saltswap_parameter_pairs.append(tuple([water_params, anion_params]))
+
+                # Forward: probability of one pick is
+                # 1.0 / (n_water choose m); e.g. from all waters select m (the wat2ani count).
+                log_p_forward = -np.log(comb(all_waters.size, swaps['wat2ani'], exact=True))
+                # Reverse: probability of one pick is
+                # 1.0 / (n_anion + m choose m); e.g. from all current anions plus m (the wat2ani count), select m
+                log_p_reverse = -np.log(comb(all_anions.size + swaps['wat2ani'], swaps['wat2ani'], exact=True))
+                log_ratio += (log_p_reverse - log_p_forward)
+
+            if swaps['cat2wat'] > 0:
+                for cation_index in np.random.choice(a=all_cations, size=swaps['cat2wat'], replace=False):
+                    saltswap_residue_indices.append(cation_index)
+                    saltswap_parameter_pairs.append(tuple([cation_params, water_params]))
+
+                # Forward: choose m cations to change into water, probability of one pick is
+                # 1.0 / (n_cations choose m); e.g. from all cations select m (the cat2wat count).
+                log_p_forward = -np.log(comb(all_cations.size, swaps['cat2wat'], exact=True))
+                # Reverse: choose m water to change into cations, probability of one pick is
+                # 1.0 / (n_water + m choose m); e.g. from current waters plus m (the ani2wat count), select m
+                log_p_reverse = -np.log(comb(all_cations.size + swaps['cat2wat'], swaps['cat2wat'], exact=True))
+                log_ratio += (log_p_reverse - log_p_forward)
+
+            if swaps['ani2wat'] > 0:
+                for anion_index in np.random.choice(a=all_anions, size=swaps['ani2wat'], replace=False):
+                    saltswap_residue_indices.append(anion_index)
+                    saltswap_parameter_pairs.append(tuple([anion_params, water_params]))
+
+                # Forward: probability of one pick is
+                # 1.0 / (n_anions choose m); e.g. from all anions select m (the ani2wat count).
+                log_p_forward = -np.log(comb(all_anions.size, swaps['ani2wat'], exact=True))
+                # Reverse: probability of one pick is
+                # 1.0 / (n_water + m choose m); e.g. from water plus m (the ani2wat count), select m
+                log_p_reverse = -np.log(comb(all_waters.size + swaps['ani2wat'], swaps['ani2wat'], exact=True))
+                log_ratio += (log_p_reverse - log_p_forward)
+
+        return saltswap_residue_indices, saltswap_parameter_pairs, log_ratio

--- a/protons/app/proposals.py
+++ b/protons/app/proposals.py
@@ -194,7 +194,7 @@ class SaltSwapProposal:
 class UniformSwapProposal(SaltSwapProposal):
     """Uniformly selects as many water/ions as needed from the array of available waters/ions."""
 
-    def __init__(self, cation_coefficient: float = 0.5):
+    def __init__(self, cation_coefficient: float=0.5):
         """Instantiate a UniformSwapProposal.
 
         Parameters

--- a/protons/app/proposals.py
+++ b/protons/app/proposals.py
@@ -160,7 +160,7 @@ class CategoricalProposal(_StateProposal):
         return final_titration_states, titration_group_indices, 0.0
 
 
-class _SaltSwapProposal:
+class SaltSwapProposal:
     """This class is a baseclass for selecting water molecules or ions to maintain charge neutrality."""
 
     def propose_swaps(self, drive, net_charge_difference):
@@ -191,7 +191,7 @@ class _SaltSwapProposal:
         return list(), list(), float()
 
 
-class UniformSwapProposal(_SaltSwapProposal):
+class UniformSwapProposal(SaltSwapProposal):
     """Uniformly selects as many water/ions as needed from the array of available waters/ions."""
 
     def __init__(self, cation_coefficient: float = 0.5):


### PR DESCRIPTION
This is a work-in-progress PR for implementing maintaining charge neutrality. The intention is to use the 
update_fractional_ion function in `saltswap.swapper.Swapper`  to update water/ion states alongside proposals for protonation state changes. 