### PR TITLE
Chen-Roux ions scheme

### DIFF
--- a/protons/app/proposals.py
+++ b/protons/app/proposals.py
@@ -163,17 +163,18 @@ class CategoricalProposal(_StateProposal):
 class SaltSwapProposal:
     """This class is a baseclass for selecting water molecules or ions to maintain charge neutrality."""
 
-    def propose_swaps(self, drive, net_charge_difference):
+    def propose_swaps(self, drive, initial_charge: int, final_charge: int):
         """Select a series of water molecules/ions to swap.
 
         Parameters
         ----------
 
         drive - a ProtonDrive object with a swapper attached.
-        net_charge_difference - int, the total charge that needs to be countered by ions.
+        initial_charge - the total charge of the changing residue before the state change
+        total_charge - the total charge of the changing residue after the state change
 
-        Nota bene
-        ---------
+        Please note
+        -----------
         The net charge difference will have the opposite charge of the ions that will be added to the system,
         such that the resulting total charge change will be 0.
 
@@ -328,14 +329,15 @@ class UniformSwapProposal(SaltSwapProposal):
         elif swaps['anion_to_water'] != 0 and swaps['water_to_anion'] != 0:
             raise RuntimeError("Anions are being added and removed at the same time. This is a bug in the code.")
 
-    def propose_swaps(self, drive, net_charge_difference):
+    def propose_swaps(self, drive, initial_charge: int, final_charge: int):
         """Select a series of water molecules/ions to swap uniformly from all waters/ions.
 
             Parameters
             ----------
 
             drive - a ProtonDrive object with a swapper attached.
-            net_charge_difference - int, the total charge that needs to be countered.
+            initial_charge - the total charge of the changing residue before the state change
+            total_charge - the total charge of the changing residue after the state change
 
             Returns
             -------
@@ -348,7 +350,7 @@ class UniformSwapProposal(SaltSwapProposal):
 
             float - log (probability of reverse proposal)/(probability of forward proposal)
         """
-
+        net_charge_difference = final_charge - initial_charge
         # Defaults. If no swaps are necessary, this will be all that is needed.
         saltswap_residue_indices = list()
         saltswap_state_pairs = list()

--- a/protons/app/proposals.py
+++ b/protons/app/proposals.py
@@ -191,125 +191,6 @@ class SaltSwapProposal:
 
         return list(), list(), float()
 
-
-class UniformSwapProposal(SaltSwapProposal):
-    """Uniformly selects as many water/ions as needed from the array of available waters/ions."""
-
-    def __init__(self, cation_coefficient: float=0.5):
-        """Instantiate a UniformSwapProposal.
-
-        Parameters
-        ----------
-        cation_coefficient - float, optional. Must be between 0 and 1, default 0.5.
-            The fraction of the chemical potential of a water pair -> salt pair transformation that is attributed to the
-            cation -> water transformation.
-        """
-        if not 0.0 <= cation_coefficient <= 1.0:
-            raise ValueError("The cation coefficient should be between 0 and 1.")
-
-        self._cation_weight = cation_coefficient
-        self._anion_weight = 1.0 - cation_coefficient
-
-    @staticmethod
-    def _select_ion_water_swaps(drive, charge_to_counter):
-        """Select ions or water molecule swap procedure to facilitate maintaining charge neutrality while changing protonation states.
-
-        Notes
-        -----
-        Technically, for charge differences of 2 we could change one anion into a cation or vice versa.
-        This code would instead remove one anion, and change one water into a cation.
-
-        Parameters
-        ----------
-        drive - a ProtonDrive object
-        charge_to_counter - the total difference in charge that needs to be countered.
-
-        Returns
-        -------
-        dict(water_to_cation, water_to_anion, cation_to_water, anion_to_water)
-
-        """
-
-        # Note that we don't allow for direct transitions between ions of different charge.
-        swaps = dict(water_to_cation=0, water_to_anion=0, cation_to_water=0, anion_to_water=0)
-        excess_ions = int(drive.excess_ions)  # copy
-
-        while abs(charge_to_counter) > 0:
-
-            # A net amount of cations were previously added to the system
-            if excess_ions > 0:
-                charge_to_counter, excess_ions = UniformSwapProposal._swap_excess_cations(charge_to_counter, excess_ions, swaps)
-
-            # No additional ions were previously added by the swapper.
-            elif excess_ions == 0:
-                charge_to_counter, excess_ions = UniformSwapProposal._swap_no_excess_ions(charge_to_counter, excess_ions, swaps)
-
-            # A net amount of anions were previously added to the system
-            elif excess_ions < 0:
-                charge_to_counter, excess_ions = UniformSwapProposal._swap_excess_anions(charge_to_counter, excess_ions, swaps)
-
-        return swaps
-
-    @staticmethod
-    def _swap_excess_anions(charge_to_counter, net_ions, swaps):
-        """Adds a single unit of charge swap in the case of excess anions"""
-
-        # Need to counter positive charge by adding anion
-        if charge_to_counter > 0:
-            swaps['water_to_anion'] += 1
-            # One negative charge was added
-            net_ions -= 1
-            # One positive charge was countered
-            charge_to_counter -= 1
-        # Need to counter negative charge by removing anion
-        elif charge_to_counter < 0:
-            swaps['anion_to_water'] += 1
-            # One negative charge was removed
-            net_ions += 1
-            # One negative charge was countered
-            charge_to_counter += 1
-        return charge_to_counter, net_ions
-
-    @staticmethod
-    def _swap_no_excess_ions(charge_to_counter, net_ions, swaps):
-        """Add a neutralizing swap operation in the case of no excess ions."""
-        # Need to counter positive charge by adding anion
-        if charge_to_counter > 0:
-            swaps['water_to_anion'] += 1
-            # One negative charge was added
-            net_ions -= 1
-            # One positive charge was countered
-            charge_to_counter -= 1
-        # Need to counter negative charge by adding cation
-        elif charge_to_counter < 0:
-            swaps['water_to_cation'] += 1
-            # One positive charge was added
-            net_ions += 1
-            # One negative charge was countered
-            charge_to_counter += 1
-
-        return charge_to_counter, net_ions
-
-    @staticmethod
-    def _swap_excess_cations(charge_to_counter, net_ions, swaps):
-        """Add a swap of water/ions in the case of excess cations."""
-        # Need to counter positive charge by removing cation
-        if charge_to_counter > 0:
-            swaps['cation_to_water'] += 1
-            # One positive charge was removed
-            net_ions -= 1
-            # One positive charge was countered
-            charge_to_counter -= 1
-        # Need to counter negative charge by adding cation
-        elif charge_to_counter < 0:
-            swaps['water_to_cation'] += 1
-            # One positive charge was added
-            net_ions += 1
-            # One negative charge was countered
-            charge_to_counter += 1
-
-        return charge_to_counter, net_ions
-
     @staticmethod
     def _validate_swaps(swaps):
         """Perform sanity checks. Swaps should only add charge in one direction.
@@ -328,6 +209,126 @@ class UniformSwapProposal(SaltSwapProposal):
             raise RuntimeError("Cations are being added and removed at the same time. This is a bug in the code.")
         elif swaps['anion_to_water'] != 0 and swaps['water_to_anion'] != 0:
             raise RuntimeError("Anions are being added and removed at the same time. This is a bug in the code.")
+
+
+class OneDirectionChargeProposal(SaltSwapProposal):
+    """Swaps ions in a way that does not create opposite charges during the alchemical protocol.
+    This is an implementation of the method outlined in Chen and Roux 2015
+    """
+
+    def __init__(self, cation_coefficient: float=0.5, err_on_depletion: bool=True):
+        """Instantiate a UniformSwapProposal.
+
+        Parameters
+        ----------
+        cation_coefficient - optional. Must be between 0 and 1, default 0.5.
+            The fraction of the chemical potential of a water pair -> salt pair transformation that is attributed to the
+            cation -> water transformation.
+        err_on_depletion - optional.
+            If ions get depleted, raise an error. If false, add opposite charge ion to fix.
+
+
+        """
+        if not 0.0 <= cation_coefficient <= 1.0:
+            raise ValueError("The cation coefficient should be between 0 and 1.")
+
+        self._cation_weight = cation_coefficient
+        self._anion_weight = 1.0 - cation_coefficient
+
+        self._err_on_depletion = err_on_depletion
+
+    def select_ions(self, chem_potential: float, drive, log_ratio: float, saltswap_residue_indices:list, saltswap_state_pairs:list, swaps: dict):
+        """
+
+        Parameters
+        ----------
+        chem_potential - used to calculate the probability of the swap
+        drive - ProtonDrive object that has a swapper attached
+        log_ratio - starting log_ratio estimate
+        saltswap_residue_indices - list to append residue indices to
+        saltswap_state_pairs - list to append initial and final states of residues to
+        swaps - dict of the type of swaps to perform
+
+        Returns
+        -------
+
+        """
+        all_waters = np.where(drive.swapper.stateVector == 0)[0]
+        all_cations = np.where(drive.swapper.stateVector == 1)[0]
+        all_anions = np.where(drive.swapper.stateVector == 2)[0]
+        # This code should only perform water_to_cation OR water_to_anion, not both.
+        # The sanity check should prevent the same waters/ions from being selected twice.
+        # individual types of swaps should be completely independent for the purpose of calculating
+        # the proposal probabilities.
+        if swaps['water_to_cation'] > 0:
+            for water_index in np.random.choice(a=all_waters, size=swaps['water_to_cation'], replace=False):
+                saltswap_residue_indices.append(water_index)
+                saltswap_state_pairs.append(tuple([0, 1]))
+
+            # Forward: choose m water to change into cations, probability of one pick is
+            # 1.0 / (n_water choose m); e.g. from all waters select m (the water_to_cation count).
+            log_p_forward = -np.log(comb(all_waters.size, swaps['water_to_cation'], exact=True))
+            # Reverse: choose m cations to change into water, probability of one pick is
+            # 1.0 / (n_cation + m choose m); e.g. from current cations plus m (the water_to_cation count), select m
+            log_p_reverse = -np.log(
+                comb(all_cations.size + swaps['water_to_cation'], swaps['water_to_cation'], exact=True))
+            log_ratio += (log_p_reverse - log_p_forward)
+            # Calculate the work of transforming one water molecule into a cation
+            work = chem_potential * self._cation_weight
+            # Subtract the work from the acceptance probability
+            log_ratio -= work
+        if swaps['water_to_anion'] > 0:
+            for water_index in np.random.choice(a=all_waters, size=swaps['water_to_anion'], replace=False):
+                saltswap_residue_indices.append(water_index)
+                saltswap_state_pairs.append(tuple([0, 2]))
+
+            # Forward: probability of one pick is
+            # 1.0 / (n_water choose m); e.g. from all waters select m (the water_to_anion count).
+            log_p_forward = -np.log(comb(all_waters.size, swaps['water_to_anion'], exact=True))
+            # Reverse: probability of one pick is
+            # 1.0 / (n_anion + m choose m); e.g. from all current anions plus m (the water_to_anion count), select m
+            log_p_reverse = -np.log(
+                comb(all_anions.size + swaps['water_to_anion'], swaps['water_to_anion'], exact=True))
+            log_ratio += (log_p_reverse - log_p_forward)
+            # Calculate the work of transforming one water into one anion
+            work = chem_potential * self._anion_weight
+            # Subtract the work from the acceptance probability
+            log_ratio -= work
+        if swaps['cation_to_water'] > 0:
+            for cation_index in np.random.choice(a=all_cations, size=swaps['cation_to_water'], replace=False):
+                saltswap_residue_indices.append(cation_index)
+                saltswap_state_pairs.append(tuple([1, 0]))
+
+            # Forward: choose m cations to change into water, probability of one pick is
+            # 1.0 / (n_cations choose m); e.g. from all cations select m (the cation_to_water count).
+            log_p_forward = -np.log(comb(all_cations.size, swaps['cation_to_water'], exact=True))
+            # Reverse: choose m water to change into cations, probability of one pick is
+            # 1.0 / (n_water + m choose m); e.g. from current waters plus m (the anion_to_water count), select m
+            log_p_reverse = -np.log(
+                comb(all_cations.size + swaps['cation_to_water'], swaps['cation_to_water'], exact=True))
+            log_ratio += (log_p_reverse - log_p_forward)
+            # Calculate the work of transforming one cation into one water molecule
+            work = -chem_potential * self._cation_weight
+            # Subtract the work from the acceptance probability
+            log_ratio -= work
+        if swaps['anion_to_water'] > 0:
+            for anion_index in np.random.choice(a=all_anions, size=swaps['anion_to_water'], replace=False):
+                saltswap_residue_indices.append(anion_index)
+                saltswap_state_pairs.append(tuple([2, 0]))
+
+            # Forward: probability of one pick is
+            # 1.0 / (n_anions choose m); e.g. from all anions select m (the anion_to_water count).
+            log_p_forward = -np.log(comb(all_anions.size, swaps['anion_to_water'], exact=True))
+            # Reverse: probability of one pick is
+            # 1.0 / (n_water + m choose m); e.g. from water plus m (the anion_to_water count), select m
+            log_p_reverse = -np.log(
+                comb(all_waters.size + swaps['anion_to_water'], swaps['anion_to_water'], exact=True))
+            log_ratio += (log_p_reverse - log_p_forward)
+            # Calculate the work of transforming one anion into water based on the chemical potential
+            work = -chem_potential * self._anion_weight
+            # Subtract the work from the acceptance probability
+            log_ratio -= work
+        return log_ratio
 
     def propose_swaps(self, drive, initial_charge: int, final_charge: int):
         """Select a series of water molecules/ions to swap uniformly from all waters/ions.
@@ -371,87 +372,61 @@ class UniformSwapProposal(SaltSwapProposal):
         if net_charge_difference != 0:
 
             # There is a net charge difference, find which swaps are necessary to compute.
-            swaps = self._select_ion_water_swaps(drive, net_charge_difference)
+            swaps = self._select_swaps_chenroux(initial_charge, final_charge)
 
             # Apply sanity checks
-            UniformSwapProposal._validate_swaps(swaps)
+            SaltSwapProposal._validate_swaps(swaps)
 
-            all_waters = np.where(drive.swapper.stateVector == 0)[0]
-            all_cations = np.where(drive.swapper.stateVector == 1)[0]
-            all_anions = np.where(drive.swapper.stateVector == 2)[0]
-
-
-            # This code should only perform water_to_cation OR water_to_anion, not both.
-            # The sanity check should prevent the same waters/ions from being selected twice.
-            # individual types of swaps should be completely independent for the purpose of calculating
-            # the proposal probabilities.
-
-            if swaps['water_to_cation'] > 0:
-                for water_index in np.random.choice(a=all_waters, size=swaps['water_to_cation'], replace=False):
-                    saltswap_residue_indices.append(water_index)
-                    saltswap_state_pairs.append(tuple([0, 1]))
-
-                # Forward: choose m water to change into cations, probability of one pick is
-                # 1.0 / (n_water choose m); e.g. from all waters select m (the water_to_cation count).
-                log_p_forward = -np.log(comb(all_waters.size, swaps['water_to_cation'], exact=True))
-                # Reverse: choose m cations to change into water, probability of one pick is
-                # 1.0 / (n_cation + m choose m); e.g. from current cations plus m (the water_to_cation count), select m
-                log_p_reverse = -np.log(comb(all_cations.size + swaps['water_to_cation'], swaps['water_to_cation'], exact=True))
-                log_ratio += (log_p_reverse - log_p_forward)
-                # Calculate the work of transforming one water molecule into a cation
-                work = chem_potential * self._cation_weight
-                # Subtract the work from the acceptance probability
-                log_ratio -= work
-
-            if swaps['water_to_anion'] > 0:
-                for water_index in np.random.choice(a=all_waters, size=swaps['water_to_anion'], replace=False):
-                    saltswap_residue_indices.append(water_index)
-                    saltswap_state_pairs.append(tuple([0, 2]))
-
-                # Forward: probability of one pick is
-                # 1.0 / (n_water choose m); e.g. from all waters select m (the water_to_anion count).
-                log_p_forward = -np.log(comb(all_waters.size, swaps['water_to_anion'], exact=True))
-                # Reverse: probability of one pick is
-                # 1.0 / (n_anion + m choose m); e.g. from all current anions plus m (the water_to_anion count), select m
-                log_p_reverse = -np.log(comb(all_anions.size + swaps['water_to_anion'], swaps['water_to_anion'], exact=True))
-                log_ratio += (log_p_reverse - log_p_forward)
-                # Calculate the work of transforming one water into one anion
-                work = chem_potential * self._anion_weight
-                # Subtract the work from the acceptance probability
-                log_ratio -= work
-
-            if swaps['cation_to_water'] > 0:
-                for cation_index in np.random.choice(a=all_cations, size=swaps['cation_to_water'], replace=False):
-                    saltswap_residue_indices.append(cation_index)
-                    saltswap_state_pairs.append(tuple([1, 0]))
-
-                # Forward: choose m cations to change into water, probability of one pick is
-                # 1.0 / (n_cations choose m); e.g. from all cations select m (the cation_to_water count).
-                log_p_forward = -np.log(comb(all_cations.size, swaps['cation_to_water'], exact=True))
-                # Reverse: choose m water to change into cations, probability of one pick is
-                # 1.0 / (n_water + m choose m); e.g. from current waters plus m (the anion_to_water count), select m
-                log_p_reverse = -np.log(comb(all_cations.size + swaps['cation_to_water'], swaps['cation_to_water'], exact=True))
-                log_ratio += (log_p_reverse - log_p_forward)
-                # Calculate the work of transforming one cation into one water molecule
-                work = -chem_potential * self._cation_weight
-                # Subtract the work from the acceptance probability
-                log_ratio -= work
-
-            if swaps['anion_to_water'] > 0:
-                for anion_index in np.random.choice(a=all_anions, size=swaps['anion_to_water'], replace=False):
-                    saltswap_residue_indices.append(anion_index)
-                    saltswap_state_pairs.append(tuple([2, 0]))
-
-                # Forward: probability of one pick is
-                # 1.0 / (n_anions choose m); e.g. from all anions select m (the anion_to_water count).
-                log_p_forward = -np.log(comb(all_anions.size, swaps['anion_to_water'], exact=True))
-                # Reverse: probability of one pick is
-                # 1.0 / (n_water + m choose m); e.g. from water plus m (the anion_to_water count), select m
-                log_p_reverse = -np.log(comb(all_waters.size + swaps['anion_to_water'], swaps['anion_to_water'], exact=True))
-                log_ratio += (log_p_reverse - log_p_forward)
-                # Calculate the work of transforming one anion into water based on the chemical potential
-                work = -chem_potential * self._anion_weight
-                # Subtract the work from the acceptance probability
-                log_ratio -= work
+            log_ratio = self.select_ions(chem_potential, drive, log_ratio, saltswap_residue_indices,
+                                         saltswap_state_pairs, swaps)
 
         return saltswap_residue_indices, saltswap_state_pairs, log_ratio
+
+    @staticmethod
+    def _select_swaps_chenroux(initial_charge: int, final_charge: int) -> dict:
+        """Select ions or water molecule swap procedure to facilitate maintaining charge neutrality while changing protonation states.
+
+        Notes
+        -----
+        Based on the method from Chen and Roux 2015.
+
+        Parameters
+        ----------
+        initial_charge - the initial charge of the residue
+        final_charge - the state of the residue after changing protonation states
+
+        Returns
+        -------
+        dict(water_to_cation, water_to_anion, cation_to_water, anion_to_water)
+
+        """
+
+        # Note that we don't allow for direct transitions between ions of different charge.
+        swaps = dict(water_to_cation=0, water_to_anion=0, cation_to_water=0, anion_to_water=0)
+        charge_to_counter = final_charge - initial_charge
+
+        while abs(charge_to_counter) > 0:
+            # The protonation state change annihilates a positive charge
+            if (initial_charge > 0 >= final_charge) or (0 < final_charge < initial_charge):
+                swaps['water_to_cation'] += 1
+                charge_to_counter += 1
+                initial_charge -= 1 # One part of the initial charge has been countered
+
+            # The protonation state change annihilates a negative charge
+            elif initial_charge < 0 <= final_charge or (0 > final_charge > initial_charge):
+                swaps['water_to_anion'] += 1
+                charge_to_counter -= 1
+                initial_charge += 1
+            # The protonation state change adds a negative charge
+            elif initial_charge == 0 > final_charge or (0 > initial_charge > final_charge):
+                swaps['anion_to_water'] += 1
+                charge_to_counter += 1
+                initial_charge -= 1
+            # The protonation state adds a positive charge
+            elif (initial_charge == 0 < final_charge) or (0 < initial_charge < final_charge):
+                swaps['cation_to_water'] += 1
+                charge_to_counter -= 1
+                initial_charge += 1
+            else:
+                raise ValueError("Impossible scenario reached.")
+        return swaps

--- a/protons/tests/test_explicit.py
+++ b/protons/tests/test_explicit.py
@@ -1,22 +1,25 @@
 from __future__ import print_function
 
-import pytest
 import os
+from collections import Counter
+from copy import deepcopy
+
+import numpy as np
+import pytest
+from lxml import etree
+from numpy.random import choice
+from saltswap.swapper import Swapper
+from saltswap.wrappers import Salinator
 from simtk import unit, openmm
+
 from protons import app
 from protons.app import AmberProtonDrive, ForceFieldProtonDrive, NCMCProtonDrive
+from protons.app import ForceField
 from protons.app import SelfAdjustedMixtureSampling
 from protons.app import UniformProposal
 from protons.app.proposals import OneDirectionChargeProposal
-from protons.app import Topology
-from saltswap.swapper import Swapper
-from saltswap.wrappers import Salinator
-from protons.app import ForceField
-from lxml import etree
 from . import get_test_data
 from .utilities import SystemSetup, create_compound_gbaoab_integrator, hasCUDA
-import numpy as np
-from collections import Counter
 
 
 class TestAmberTyrosineExplicit(object):
@@ -732,4 +735,103 @@ class TestForceFieldImidazoleSaltswap:
             tot_charge += np.float64(q)
 
         return tot_charge
+
+
+class TestIonSwapping:
+    """This class contains some simulation-independent testing features of schemes for selecting what ions need to be
+    added/removed from a simulation to facilitate charge changes."""
+
+    histidine = np.asarray([0, 0, +1], dtype=int) # Has two neutral states, and one positive state
+    aspartate = np.asarray([-1, 0, 0, 0, 0], dtype=int) # Has 4 neutral syn/anti hydrogen positions, also covers glutamate
+    lysine = np.asarray([0, +1], dtype=int)
+    tyrosine = np.asarray([0, -1], dtype=int)
+
+    diprotic_acid = np.asarray([-2, -1, -1, 0], dtype=int)
+    diprotic_base = np.asarray([0, 1, 1, 2], dtype=int)
+    zwitter_one = np.asarray([1, 0, 0, -1], dtype=int)
+    zwitter_two = np.asarray([-2, -1, -1, -1, -1, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2], dtype=int)
+
+    residues = {'His': histidine,
+                'Asp': aspartate,
+                'Glu': deepcopy(aspartate),
+                'Cys': deepcopy(tyrosine),
+                'Tyr': tyrosine,
+                'Lys': lysine,
+                'Diprotic acid': diprotic_acid,
+                'Diprotic base': diprotic_base,
+                'Zwitter ion': zwitter_one,
+                'Double zwitter ion': zwitter_two}
+
+    def test_accumulation_chen_roux_swap_proposals(self):
+        """
+        Select ion swaps for a hypothetical chain of protonation state changes.
+        """
+
+        n_samples = 1000
+        for resname, residue in TestIonSwapping.residues.items():
+            max_anions, max_cations, min_anions, min_cations, span_q = self.sample_residue_trajectory_chenroux(n_samples,
+                                                                                                      residue)
+
+            self._check_for_accumulation_depletion(max_anions, max_cations, min_anions, min_cations, resname, span_q)
+
+    @staticmethod
+    def sample_residue_trajectory_chenroux(n_samples: int, residue: np.ndarray):
+        """
+        For a given residue, randomly sample a trajectory of states from it.
+        """
+        # initial charge, and initial counterions
+        res_charge = [residue[0]]
+        # If residue is negative, add cations
+        ncat = [- res_charge[0]] if res_charge[0] < 0 else [0]
+        # If residue is positive, add anions
+        nani = [- res_charge[0]] if res_charge[0] > 0 else [0]
+        for x in range(n_samples):
+            initial_charge = res_charge[x]
+            final_charge = choice(residue)
+            swaps = OneDirectionChargeProposal._select_swaps_chenroux(initial_charge, final_charge)
+            cat = 0
+            cat += swaps['water_to_cation']
+            cat -= swaps['cation_to_water']
+            ani = 0
+            ani += swaps['water_to_anion']
+            ani -= swaps['anion_to_water']
+
+            ncat.append(ncat[x] + cat)
+            nani.append(nani[x] + ani)
+            res_charge.append(final_charge)
+
+        deltaq = [0]  # first delta is 0
+        deltaq.extend(list(res_charge[x + 1] - res_charge[x] for x in range(n_samples)))
+        delta_cat = [0]
+        delta_cat.extend(list(ncat[x + 1] - ncat[x] for x in range(n_samples)))
+        delta_ani = [0]
+        delta_ani.extend(list(nani[x + 1] - nani[x] for x in range(n_samples)))
+
+        max_q = np.max(res_charge)
+        min_q = np.min(res_charge)
+        span_q = max_q - min_q
+        max_anions = np.max(nani)
+        min_anions = np.min(nani)
+        max_cations = np.max(ncat)
+        min_cations = np.min(ncat)
+        return max_anions, max_cations, min_anions, min_cations, span_q
+
+    @staticmethod
+    def _check_for_accumulation_depletion(max_anions: int, max_cations: int, min_anions: int, min_cations: int, resname: str, span_q: int):
+        """
+        Given some properties of the residue, and the ion depletion, assert whether accumulation or depletion of ions is occuring
+        """
+
+        assert span_q >= max_anions, "The number of anions for residue {} is too large, could indicate " \
+                                     "accumulation of ions. Largest q_span: {} anions: {}".format(resname, span_q,
+                                                                                                  max_anions)
+        assert span_q >= max_cations, "The number of cations for residue {} is too large, could indicate " \
+                                      "accumulation of ions. Largest_q_span q: {} cations: {}".format(resname, span_q,
+                                                                                                      max_cations)
+        assert span_q >= abs(min_anions), "The number of anions for residue {} is too small, could indicate " \
+                                          "depletion of ions. Largest q_span: {} anions: {}".format(resname, span_q,
+                                                                                                    min_anions)
+        assert span_q >= abs(min_cations), "The number of cations for residue {} is too small, could indicate " \
+                                           "depletion of ions. Largest_q_span q: {} cations: {}".format(resname, span_q,
+                                                                                                        max_cations)
 

--- a/protons/tests/test_explicit.py
+++ b/protons/tests/test_explicit.py
@@ -7,7 +7,7 @@ from protons import app
 from protons.app import AmberProtonDrive, ForceFieldProtonDrive, NCMCProtonDrive
 from protons.app import SelfAdjustedMixtureSampling
 from protons.app import UniformProposal
-from protons.app.proposals import UniformSwapProposal
+from protons.app.proposals import OneDirectionChargeProposal
 from protons.app import Topology
 from saltswap.swapper import Swapper
 from saltswap.wrappers import Salinator
@@ -665,19 +665,18 @@ class TestForceFieldImidazoleSaltswap:
         driver.attach_swapper(swapper)
 
         driver.adjust_to_ph(7.4)
-        swap_proposal = UniformSwapProposal()
+        swap_proposal = OneDirectionChargeProposal()
         old_charge = self.calculate_explicit_solvent_system_charge(driver.system)
         # The initial state is neutral, the new state is +1
-        net_charge_difference = 1.0
         # Pick swaps using the proposal method explicitly.
-        saltswap_residue_indices, saltswap_state_pairs, log_ratio = swap_proposal.propose_swaps(driver, net_charge_difference)
+        saltswap_residue_indices, saltswap_state_pairs, log_ratio = swap_proposal.propose_swaps(driver, 0, 1)
         # First residue is updates from state 0, to state 1, and the previously selected salt swap is added to the protocol
         driver._perform_ncmc_protocol([0],np.asarray([0]),np.asarray([1]), salt_residue_indices=saltswap_residue_indices, salt_states=saltswap_state_pairs)
 
         # This should be the same as the old charge
         new_charge = self.calculate_explicit_solvent_system_charge(driver.system)
         # Bookkeeping
-        driver.excess_ions -= net_charge_difference
+        driver.excess_ions -= 1
 
         # The saltswap indices are updated to indicate the change of species
         for saltswap_residue, (from_ion_state, to_ion_state) in zip(saltswap_residue_indices, saltswap_state_pairs):

--- a/protons/tests/test_implicit.py
+++ b/protons/tests/test_implicit.py
@@ -22,6 +22,7 @@ except ValueError:
 found_schrodinger = is_schrodinger_suite_installed()
 
 
+@pytest.mark.skip(reason="Implicit solvent support is disabled.")
 class TestAmberTyrosineImplicit(object):
     """Simulating a tyrosine in implicit solvent"""
     default_platform = 'CPU'
@@ -131,6 +132,7 @@ class TestAmberTyrosineImplicit(object):
         driver.update(UniformProposal(), nattempts=10)  # protonation
 
 
+@pytest.mark.skip(reason="Implicit solvent support is disabled.")
 class TestAmberPeptideImplicit(object):
     """Implicit solvent tests for a peptide with the sequence EDYCHK"""
     default_platform = 'Reference'

--- a/protons/tests/test_ligands.py
+++ b/protons/tests/test_ligands.py
@@ -56,58 +56,6 @@ class TestLigandParameterizationImplicit(object):
                                "/tmp/protons-imatinib-parameterization-test-implicit.xml",
                                pH=7.4)
 
-    @pytest.mark.skipif(not hasOpenEye, reason="This test requires OpenEye.")
-    def test_xml_compilation(self):
-        """
-        Compile an xml file for the isomers and read it in OpenMM
-        """
-        from openeye import oechem
-        isomers = OrderedDict()
-        isomer_index = 0
-        store = False
-
-        for line in open(get_test_data("epik.sdf", "testsystems/imidazole_implicit"), 'r'):
-            # for line in open('/tmp/tmp3qp7lep7/epik.sdf', 'r'):
-            if store:
-                epik_penalty = line.strip()
-
-                if store == "log_population":
-                    isomers[isomer_index]['epik_penalty'] = epik_penalty
-                    epik_penalty = float(epik_penalty)
-                    # Epik reports -RT ln p
-                    # Divide by -RT in kcal/mol/K at 25 Celsius (Epik default)
-                    isomers[isomer_index]['log_population'] = epik_penalty / (-298.15 * 1.9872036e-3)
-
-                # NOTE: relies on state penalty coming before charge
-                if store == "net_charge":
-                    isomers[isomer_index]['net_charge'] = int(epik_penalty)
-                    isomer_index += 1
-
-                store = ""
-
-            elif "r_epik_State_Penalty" in line:
-                # Next line contains epik state penalty
-                store = "log_population"
-                isomers[isomer_index] = dict()
-
-            elif "i_epik_Tot_Q" in line:
-                # Next line contains charge
-                store = "net_charge"
-
-        ifs = oechem.oemolistream()
-        ifs.open(get_test_data("epik.mol2", "testsystems/imidazole_implicit"))
-
-        xmlparser = etree.XMLParser(remove_blank_text=True, remove_comments=True)
-        for isomer_index, oemolecule in enumerate(ifs.GetOEMols()):
-            # generateForceFieldFromMolecules takes a list
-            ffxml = omtff.generateForceFieldFromMolecules([oemolecule], normalize=False)
-            isomers[isomer_index]['ffxml'] = etree.fromstring(ffxml, parser=xmlparser)
-
-        compiler = _TitratableForceFieldCompiler(isomers)
-        output_xml = '/tmp/imidazole-implicit.cph.xml'
-        compiler.write(output_xml)
-        forcefield = app.ForceField(output_xml)
-
     def test_reading_validated_xml_file_using_forcefield(self):
         """
         Read the xmlfile using app.ForceField


### PR DESCRIPTION
This still needed to be merged into master, since it is needed for production runs. 

Implementation of ion selection from Chen-Roux 2015 paper, extended to deal with ligands/charge changes larger than one unit. Key thing is that alchemical charges are only added/deleted in one direction, as recommended by Chen and Roux, as opposed to creation/destruction of opposite charges.

The proposal mechanism is called `OneDirectionChargeProposal`.

Also adds tests that actually ensure that accumulation of ions doesn't happen. Large improvement over old test is that the ion scheme is tested without actually having to run a simulation. Much faster now, and doesn't require CUDA (or OpenMM really). It uses a fictional MC chain of protonation states from realistic residue types and keeps track of what salt would have been added/removed to maintain charge neutrality.

Should be good to merge if builds pass.