### PR TITLE
Fix major bug in ncmc protocol for ions

### DIFF
--- a/protons/app/driver.py
+++ b/protons/app/driver.py
@@ -1842,7 +1842,7 @@ class NCMCProtonDrive(_BaseDrive):
                 # Only perform NCMC when the proposed state is different from the current state
                 if initial_titration_states != final_titration_states:
                     # Run NCMC integration.
-                    if self.swapper:
+                    if self.swapper is not None:
                         self._perform_ncmc_protocol(titration_group_indices, initial_titration_states, final_titration_states, saltswap_residue_indices, saltswap_states)
                     else:
                         work = 

--- a/protons/app/driver.py
+++ b/protons/app/driver.py
@@ -1842,7 +1842,10 @@ class NCMCProtonDrive(_BaseDrive):
                 # Only perform NCMC when the proposed state is different from the current state
                 if initial_titration_states != final_titration_states:
                     # Run NCMC integration.
-                    work = self._perform_ncmc_protocol(titration_group_indices, initial_titration_states, final_titration_states)
+                    if self.swapper:
+                        self._perform_ncmc_protocol(titration_group_indices, initial_titration_states, final_titration_states, saltswap_residue_indices, saltswap_states)
+                    else:
+                        work = 
                 else:
                     work = 0.0
                     for step in range(self.perturbations_per_trial):

--- a/protons/app/driver.py
+++ b/protons/app/driver.py
@@ -1845,7 +1845,7 @@ class NCMCProtonDrive(_BaseDrive):
                     if self.swapper is not None:
                         self._perform_ncmc_protocol(titration_group_indices, initial_titration_states, final_titration_states, saltswap_residue_indices, saltswap_states)
                     else:
-                        work = 
+                        work = self._perform_ncmc_protocol(titration_group_indices, initial_titration_states, final_titration_states)
                 else:
                     work = 0.0
                     for step in range(self.perturbations_per_trial):


### PR DESCRIPTION
Why:

Ions were not being added to the ncmc protocol by mistake.

What:

The call to _perform_ncmc_protocol has been updated to now actually take ions into account.