### PR TITLE
Ligand test fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ benchmarks/
 _build
 # vscode 
 .vscode/
+.env
+

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - hdf4 >4.2.11 # Pinned because of issue with netcdf4
     - joblib
     - lxml
-    - parmed
+    - parmed <=2.7.3
     - pytest
     - pytest-runner
     - pymbar
@@ -45,6 +45,7 @@ requirements:
     - openmoltools >=0.7.5
     - openmmtools >=0.9.3
     - ambermini >=15.0.4
+    - parmed <=2.7.3
     - joblib
     - lxml
     - parmed


### PR DESCRIPTION
While working with @wiederm, we found out that forcefield templates were not being generated accurately. For the time being, the fix is to pin parmed to version 2.7.3

Additionally, the tests have been extended to now catch this potential issue in the future. 

 