### PR TITLE
Array copy bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ _build
 .vscode/
 .env
 
+# mypy linting
+.mypy_cache/
+
+# py.test test runner
+.pytest_cache/

--- a/protons/app/driver.py
+++ b/protons/app/driver.py
@@ -1968,8 +1968,8 @@ class NCMCProtonDrive(_BaseDrive):
         attempt_data.logp_ratio_residue_proposal = logp_ratio_residue_proposal
 
         if self.swapper is not None:
-            initial_ion_states = self.swapper.stateVector[:]
-            proposed_ion_states = self.swapper.stateVector[:]            
+            initial_ion_states = copy.deepcopy(self.swapper.stateVector)
+            proposed_ion_states = copy.deepcopy(self.swapper.stateVector)        
             net_charge_difference = self._calculate_charge_differences(initial_titration_states, final_titration_states, titration_group_indices)
             saltswap_residue_indices, saltswap_states, logp_ratio_salt_proposal = self.swap_proposal.propose_swaps(self, initial_charge, final_charge)
             
@@ -1983,8 +1983,7 @@ class NCMCProtonDrive(_BaseDrive):
         
 
         try:
-            # Compute work for switching to new protonation states.
-
+            # Compute work for switching to new protonation states.            
             # 0 is the shortcut for instantaneous Monte Carlo
             if self.perturbations_per_trial == 0:
                 # Use instantaneous switching.
@@ -1996,8 +1995,8 @@ class NCMCProtonDrive(_BaseDrive):
                         for saltswap_residue, (from_ion_state, to_ion_state) in zip(saltswap_residue_indices, saltswap_states):
                             from_parameter = self._ion_parameters[from_ion_state]
                             to_parameter = self._ion_parameters[to_ion_state]
-                            self.swapper.update_fractional_ion(saltswap_residue, from_parameter, to_parameter, 1.0)
-
+                            self.swapper.update_fractional_ion(saltswap_residue, from_parameter, to_parameter, 1.0)                
+                
                 # Push parameter updates to the context
                 for force_index, force in enumerate(self.forces_to_update):
                     force.updateParametersInContext(self.context)

--- a/protons/app/ncmcreporter.py
+++ b/protons/app/ncmcreporter.py
@@ -4,6 +4,7 @@
 import netCDF4
 import time
 import numpy as np
+from copy import deepcopy
 
 
 class NCMCReporter:
@@ -195,5 +196,5 @@ class NCMCReporter:
         simulation - ConstantPHSimulation
         """
         if self._cumulative_work_interval > 0:
-            self._grp["perturbation"][:] = self._perturbation_steps[:]
+            self._grp["perturbation"][:] = deepcopy(self._perturbation_steps[:])
         return

--- a/protons/app/samsreporter.py
+++ b/protons/app/samsreporter.py
@@ -3,7 +3,7 @@
 
 import netCDF4
 import time
-
+from copy import deepcopy
 
 class SAMSReporter:
     """SamsReporter outputs SAMS data from a ConstantPHCalibration to a netCDF4 file."""
@@ -91,7 +91,7 @@ class SAMSReporter:
         iadapt = self._adaptation
         # The iteration of the protonation state update attempt. [update]
         self._grp['adaptation'][iadapt] = calibration.current_adaptation
-        self._grp['g_k'][iadapt,:] = calibration.last_gk[:]
+        self._grp['g_k'][iadapt,:] = deepcopy(calibration.last_gk[:])
         self._grp['flatness'][iadapt] = calibration.last_dev
 
         self._grp['stage'][0] = calibration.stage

--- a/protons/app/titrationreporter.py
+++ b/protons/app/titrationreporter.py
@@ -7,6 +7,7 @@ import numpy as np
 from simtk.openmm import NonbondedForce
 from math import floor
 from simtk.unit import elementary_charge
+from copy import deepcopy
 
 # openmm aliases for water in pdbnames
 # ion names from ions xml files in protons.
@@ -102,7 +103,7 @@ class TitrationReporter:
                 if status != 1:
                     topo_index = residue.atom_indices[iatom]
                     all_stat[topo_index] = False
-        self._grp['atom_status'][iupdate, :] = all_stat[:]
+        self._grp['atom_status'][iupdate, :] = deepcopy(all_stat[:])
         # From simtk.openmm.app.modeller
         self._grp['complex_charge'][iupdate] = self._get_total_charge(self._all_minus_solvent_indices)
 
@@ -112,7 +113,7 @@ class TitrationReporter:
 
         # Store salt identities
         if self._nsaltsites > 0:
-            self._grp['ionic_species'][iupdate,:] = drv.swapper.stateVector[:]
+            self._grp['ionic_species'][iupdate,:] = deepcopy(drv.swapper.stateVector[:])
 
     def _get_total_charge(self, particle_indices):
         """Returns total charge as integer for specified particles."""


### PR DESCRIPTION
This uses deepcopy for numpy arrays used inside attempt_state_change. Potentially the main cause of #124 

A short description of the problem:

If you index a list in python with `my_list[:]`, this returns a copy of the entire list. For numpy arrays,
it returns a reference to the array. This leads to unexpected side effects when copying is intended. I've replaced array slices with deepcopy in several places in the code where copy was the intended behavior.