### PR TITLE
Hotfix for histogram counts

### DIFF
--- a/protons/app/driver.py
+++ b/protons/app/driver.py
@@ -1035,6 +1035,12 @@ class _SAMSState:
         elif self.approach is SAMSApproach.MULTISITE:
             self._observed_table = counts.reshape(self._observed_table.shape)
 
+    def reset_observed_counts(self):
+        """Reset the observed counts to zero."""
+        self.observed_counts = np.zeros_like(self.observed_counts)
+
+        return
+
     def state_index(self, titration_states) -> int:
         """Find the index of the current titration state in the flattened arrays."""
         if self.approach is SAMSApproach.ONESITE:

--- a/protons/app/driver.py
+++ b/protons/app/driver.py
@@ -993,6 +993,18 @@ class _SAMSState:
             return self._observed_table.flatten()
 
     @property
+    def deviation_from_target(self) -> np.ndarray:
+        """Return the signed deviation from target for every state."""
+        # Ensure normalization works even if all observations are zero.
+        total = max(1.0, np.sum(self.observed_counts))
+        return (self.observed_counts / total) - self.targets
+
+    @property
+    def max_absolute_deviation(self) -> float:
+        """Return the maximum absolute deviation between sampled and target histogram."""
+        return np.max(np.abs(self.deviation_from_target))
+
+    @property
     def free_energies(self) -> np.ndarray:
         """Return entire row of sams free energies."""
         if self.approach is SAMSApproach.ONESITE:


### PR DESCRIPTION
This fixes the bug where deviation from the target was not calculated properly upon resuming.

![image](https://user-images.githubusercontent.com/3977731/53122597-f52d6b00-3524-11e9-897b-80186a7e9979.png)

The code now resets the count whenever it reaches a new stage, and it keeps track of the histogram count when the equilibrium stage is reached. I also set the criterion to switch to equilibrium to be less tight. 