### PR TITLE
Hotfix: pin openmm version for build

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -12,7 +12,7 @@ build:
 requirements:
   build:
     - python
-    - openmm >=7.2
+    - openmm >7.3
     - numpy >=1.10
     - scipy >=0.17.0
     - mdtraj # For extracting trajectory parts
@@ -36,7 +36,7 @@ requirements:
 
   run:
     - python
-    - openmm >=7.2
+    - openmm >7.3
     - numpy >=1.10
     - scipy >=0.17.0
     - mdtraj # For extracting trajectory parts

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: protons-dev
-  version: !!str 0.0.1
+  version: !!str 0.0.1a6
 
 source:
   path: ../../


### PR DESCRIPTION
I forgot to pin the openmm version to < 7.3 (needed due to precision bug).