### PR TITLE
Fix the title of molecules used for charges

### DIFF
--- a/protons/app/ligands.py
+++ b/protons/app/ligands.py
@@ -1449,6 +1449,9 @@ def generate_protons_ffxml(
     for isomer_index, oemolecule in enumerate(ifs.GetOEMols()):
         # generateForceFieldFromMolecules needs a list
         # Make new ffxml for each isomer
+
+        # Ensure that name is simple and has no space in it
+        oemolecule.SetTitle(f"ISOMER-{isomer_index}")
         log.debug("ffxml generation for {}".format(isomer_index))
         ffxml = omtff.generateForceFieldFromMolecules([oemolecule], normalize=False)
         log.debug(ffxml)


### PR DESCRIPTION
The molecule title should not have spaces in it. This causes problems
where antechamber silently replaces all charges with 0.0. This fix adds
a unique title without spaces for the purpose of charge generation.

N.B: It does not affect the final title of the molecule in the template, but simply
works around the issue.