### PR TITLE
Storing NCMC coordinates

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - parmed <=2.7.3
     - joblib
     - lxml
+    - openeye-toolkits
     - pymbar
     - seaborn
     - matplotlib
@@ -45,6 +46,7 @@ requirements:
     - ambermini >=15.0.4
     - parmed <=2.7.3
     - joblib
+    - openeye-toolkits
     - lxml
     - pymbar
     - seaborn

--- a/protons/tests/test_ncmcreporter.py
+++ b/protons/tests/test_ncmcreporter.py
@@ -379,3 +379,88 @@ class TestNCMCReporter(object):
         # Ensure clean exit
         newreporter.ncfile.sync()
         newreporter.ncfile.close()
+
+    def test_reports_with_coords(self):
+        """Instantiate a ConstantPHSimulation at 300K/1 atm for a small peptide, store_coordinates."""
+
+        pdb = app.PDBxFile(
+            get_test_data(
+                "glu_ala_his-solvated-minimized-renamed.cif", "testsystems/tripeptides"
+            )
+        )
+        forcefield = app.ForceField(
+            "amber10-constph.xml", "ions_tip3p.xml", "tip3p.xml"
+        )
+
+        system = forcefield.createSystem(
+            pdb.topology,
+            nonbondedMethod=app.PME,
+            nonbondedCutoff=1.0 * unit.nanometers,
+            constraints=app.HBonds,
+            rigidWater=True,
+            ewaldErrorTolerance=0.0005,
+        )
+
+        temperature = 300 * unit.kelvin
+        integrator = GBAOABIntegrator(
+            temperature=temperature,
+            collision_rate=1.0 / unit.picoseconds,
+            timestep=2.0 * unit.femtoseconds,
+            constraint_tolerance=1.0e-7,
+            external_work=False,
+        )
+        ncmcintegrator = GBAOABIntegrator(
+            temperature=temperature,
+            collision_rate=1.0 / unit.picoseconds,
+            timestep=2.0 * unit.femtoseconds,
+            constraint_tolerance=1.0e-7,
+            external_work=True,
+        )
+
+        compound_integrator = mm.CompoundIntegrator()
+        compound_integrator.addIntegrator(integrator)
+        compound_integrator.addIntegrator(ncmcintegrator)
+        pressure = 1.0 * unit.atmosphere
+
+        system.addForce(mm.MonteCarloBarostat(pressure, temperature))
+        driver = ForceFieldProtonDrive(
+            temperature,
+            pdb.topology,
+            system,
+            forcefield,
+            ["amber10-constph.xml"],
+            pressure=pressure,
+            perturbations_per_trial=3,
+        )
+
+        simulation = app.ConstantPHSimulation(
+            pdb.topology,
+            system,
+            compound_integrator,
+            driver,
+            platform=self._default_platform,
+        )
+        simulation.context.setPositions(pdb.positions)
+        simulation.context.setVelocitiesToTemperature(temperature)
+        filename = uuid.uuid4().hex + ".nc"
+        print("Temporary file: ", filename)
+        newreporter = ncr.NCMCReporter(filename, 1, store_coords=True)
+        simulation.update_reporters.append(newreporter)
+
+        # Regular MD step
+        simulation.step(1)
+        # Update the titration states using the uniform proposal
+        simulation.update(4)
+        # Basic checks for dimension
+        assert (
+            newreporter.ncfile["Protons/NCMC"].dimensions["update"].size == 4
+        ), "There should be 4 updates recorded."
+        assert (
+            newreporter.ncfile["Protons/NCMC"].dimensions["residue"].size == 2
+        ), "There should be 2 residues recorded."
+        with pytest.raises(KeyError) as keyerror:
+            newreporter.ncfile["Protons/NCMC"].dimensions["perturbation"]
+
+        # Ensure clean exit
+        newreporter.ncfile.sync()
+        newreporter.ncfile.close()

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,4 @@ setup(
         "console_scripts": ["protons=protons.scripts.cli:cli"],
     },
     ext_modules=extensions,
-    setup_requires=["pytest-runner"],
-    tests_require=["pytest"],
 )


### PR DESCRIPTION
This PR adds the option to store the initial and final NCMC positions as part of the NCMCReporter procedure using the new "store_coords" option. A test was added to ensure the feature works.

