### PR TITLE
Bugfix: Pass sampling method to protondrive

### DIFF
--- a/protons/scripts/run_prep_ffxml.py
+++ b/protons/scripts/run_prep_ffxml.py
@@ -230,6 +230,7 @@ def run_prep_ffxml_main(jsonfile):
         pressure=pressure,
         perturbations_per_trial=100_000,
         propagations_per_step=1,
+        sampling_method=sampling_method,
     )
 
     if "reference_free_energies" in settings:


### PR DESCRIPTION
To correctly use the chosen sampling method, this option needs to be
passed to the constructor of the ProtonDrive class.